### PR TITLE
Fix issues with non-reduced RWSEs

### DIFF
--- a/cong/kbfp.cc
+++ b/cong/kbfp.cc
@@ -50,7 +50,7 @@ namespace libsemigroups {
       assert(_rws->is_confluent());
       std::vector<Element*> gens;
       for (size_t i = 0; i < _cong._nrgens; i++) {
-        gens.push_back(new RWSE(*_rws, RWS::letter_to_rws_word(i)));
+        gens.push_back(new RWSE(*_rws, i));
       }
       _semigroup = new Semigroup(gens);
       really_delete_cont(gens);
@@ -71,7 +71,7 @@ namespace libsemigroups {
     }
     assert(is_done());  // so that _semigroup != nullptr
 
-    Element* x   = new RWSE(*_rws, _rws->rewrite(RWS::word_to_rws_word(word)));
+    Element* x   = new RWSE(*_rws, word);
     size_t   pos = _semigroup->position(x);
     x->really_delete();
     delete x;

--- a/cong/kbp.cc
+++ b/cong/kbp.cc
@@ -46,7 +46,7 @@ namespace libsemigroups {
       assert(_rws->is_confluent());
       std::vector<Element*> gens;
       for (size_t i = 0; i < _cong._nrgens; i++) {
-        gens.push_back(new RWSE(*_rws, RWS::letter_to_rws_word(i)));
+        gens.push_back(new RWSE(*_rws, i));
       }
       _semigroup = new Semigroup(gens);
       really_delete_cont(gens);

--- a/rwse.cc
+++ b/rwse.cc
@@ -39,7 +39,7 @@ namespace libsemigroups {
     assert(increase_deg_by == 0);
     (void) increase_deg_by;  // to keep the compiler happy
     rws_word_t* rws_word(new rws_word_t(*(this->_rws_word)));
-    return new RWSE(_rws, rws_word, this->_hash_value);
+    return new RWSE(_rws, rws_word, false, this->_hash_value);
   }
 
   void RWSE::copy(Element const* x) {

--- a/rwse.h
+++ b/rwse.h
@@ -33,9 +33,18 @@ namespace libsemigroups {
   // This class is just a wrapper for an rws_word_t.
   class RWSE : public Element {
 
+   private:
+    RWSE(RWS* rws, rws_word_t* w, bool reduce, size_t hv)
+        : Element(hv), _rws(rws), _rws_word(w) {
+          if (reduce) {
+            rws_word_t buf;
+            _rws->rewrite(_rws_word, buf);
+          }
+        }
+
    public:
-    RWSE(RWS* rws, rws_word_t* w, size_t hv = Element::UNDEFINED)
-        : Element(hv), _rws(rws), _rws_word(w) {}
+    RWSE(RWS* rws, rws_word_t* w)
+        : RWSE(rws, w, true, Element::UNDEFINED) {}
 
     RWSE(RWS& rws, rws_word_t const& w) : RWSE(&rws, new rws_word_t(w)) {}
 

--- a/test/kbfp.test.cc
+++ b/test/kbfp.test.cc
@@ -138,3 +138,136 @@ TEST_CASE("KBFP 03: for a finite semigroup",
   delete t3;
   delete t4;
 }
+
+TEST_CASE("KBFP 04: finite fp-semigroup, dihedral group of order 6",
+          "[quick][fpsemigroup][kbfp][finite]") {
+  std::vector<relation_t> rels = {
+      relation_t({0, 0}, {0}),
+      relation_t({0, 1}, {1}),
+      relation_t({1, 0}, {1}),
+      relation_t({0, 2}, {2}),
+      relation_t({2, 0}, {2}),
+      relation_t({0, 3}, {3}),
+      relation_t({3, 0}, {3}),
+      relation_t({0, 4}, {4}),
+      relation_t({4, 0}, {4}),
+      relation_t({1, 2}, {0}),
+      relation_t({2, 1}, {0}),
+      relation_t({3, 4}, {0}),
+      relation_t({4, 3}, {0}),
+      relation_t({2, 2}, {0}),
+      relation_t({1, 4, 2, 3, 3}, {0}),
+      relation_t({4, 4, 4}, {0})};
+
+  std::vector<relation_t> extra = {};
+
+  Congruence cong("twosided", 5, rels, extra);
+  cong.force_kbfp();
+  cong.set_report(KBFP_REPORT);
+
+  REQUIRE(cong.nr_classes() == 6);
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({2}));
+}
+
+TEST_CASE("KBFP 05: finite fp-semigroup, size 16",
+          "[quick][fpsemigroup][kbfp][finite]") {
+  std::vector<relation_t> rels = {
+      relation_t({3}, {2}),
+      relation_t({0, 3}, {0, 2}),
+      relation_t({1, 1}, {1}),
+      relation_t({1, 3}, {1, 2}),
+      relation_t({2, 1}, {2}),
+      relation_t({2, 2}, {2}),
+      relation_t({2, 3}, {2}),
+      relation_t({0, 0, 0}, {0}),
+      relation_t({0, 0, 1}, {1}),
+      relation_t({0, 0, 2}, {2}),
+      relation_t({0, 1, 2}, {1, 2}),
+      relation_t({1, 0, 0}, {1}),
+      relation_t({1, 0, 2}, {0, 2}),
+      relation_t({2, 0, 0}, {2}),
+      relation_t({0, 1, 0, 1}, {1, 0, 1}),
+      relation_t({0, 2, 0, 2}, {2, 0, 2}),
+      relation_t({1, 0, 1, 0}, {1, 0, 1}),
+      relation_t({1, 2, 0, 1}, {1, 0, 1}),
+      relation_t({1, 2, 0, 2}, {2, 0, 2}),
+      relation_t({2, 0, 1, 0}, {2, 0, 1}),
+      relation_t({2, 0, 2, 0}, {2, 0, 2})};
+  std::vector<relation_t> extra = {};
+
+  Congruence cong("twosided", 4, rels, extra);
+  cong.force_kbfp();
+  cong.set_report(KBFP_REPORT);
+
+  REQUIRE(cong.nr_classes() == 16);
+  REQUIRE(cong.word_to_class_index({2}) == cong.word_to_class_index({3}));
+}
+
+TEST_CASE("KBFP 06: finite fp-semigroup, size 16",
+          "[quick][fpsemigroup][kbfp][finite]") {
+  std::vector<relation_t> rels = {
+      relation_t({2}, {1}),
+      relation_t({4}, {3}),
+      relation_t({5}, {0}),
+      relation_t({6}, {3}),
+      relation_t({7}, {1}),
+      relation_t({8}, {3}),
+      relation_t({9}, {3}),
+      relation_t({10}, {0}),
+      relation_t({0, 2}, {0, 1}),
+      relation_t({0, 4}, {0, 3}),
+      relation_t({0, 5}, {0, 0}),
+      relation_t({0, 6}, {0, 3}),
+      relation_t({0, 7}, {0, 1}),
+      relation_t({0, 8}, {0, 3}),
+      relation_t({0, 9}, {0, 3}),
+      relation_t({0, 10}, {0, 0}),
+      relation_t({1, 1}, {1}),
+      relation_t({1, 2}, {1}),
+      relation_t({1, 4}, {1, 3}),
+      relation_t({1, 5}, {1, 0}),
+      relation_t({1, 6}, {1, 3}),
+      relation_t({1, 7}, {1}),
+      relation_t({1, 8}, {1, 3}),
+      relation_t({1, 9}, {1, 3}),
+      relation_t({1, 10}, {1, 0}),
+      relation_t({3, 1}, {3}),
+      relation_t({3, 2}, {3}),
+      relation_t({3, 3}, {3}),
+      relation_t({3, 4}, {3}),
+      relation_t({3, 5}, {3, 0}),
+      relation_t({3, 6}, {3}),
+      relation_t({3, 7}, {3}),
+      relation_t({3, 8}, {3}),
+      relation_t({3, 9}, {3}),
+      relation_t({3, 10}, {3, 0}),
+      relation_t({0, 0, 0}, {0}),
+      relation_t({0, 0, 1}, {1}),
+      relation_t({0, 0, 3}, {3}),
+      relation_t({0, 1, 3}, {1, 3}),
+      relation_t({1, 0, 0}, {1}),
+      relation_t({1, 0, 3}, {0, 3}),
+      relation_t({3, 0, 0}, {3}),
+      relation_t({0, 1, 0, 1}, {1, 0, 1}),
+      relation_t({0, 3, 0, 3}, {3, 0, 3}),
+      relation_t({1, 0, 1, 0}, {1, 0, 1}),
+      relation_t({1, 3, 0, 1}, {1, 0, 1}),
+      relation_t({1, 3, 0, 3}, {3, 0, 3}),
+      relation_t({3, 0, 1, 0}, {3, 0, 1}),
+      relation_t({3, 0, 3, 0}, {3, 0, 3})};
+  std::vector<relation_t> extra = {};
+
+  Congruence cong("twosided", 11, rels, extra);
+  cong.force_kbfp();
+  cong.set_report(KBFP_REPORT);
+
+  REQUIRE(cong.nr_classes() == 16);
+  REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({5}));
+  REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({10}));
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({2}));
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({7}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({4}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({6}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({8}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({9}));
+}

--- a/test/kbp.test.cc
+++ b/test/kbp.test.cc
@@ -318,3 +318,135 @@ TEST_CASE(
   REQUIRE(nontrivial_classes[0].size() == 2);
   really_delete_partition(nontrivial_classes);
 }
+
+TEST_CASE("KBP 09: finite fp-semigroup, dihedral group of order 6",
+          "[quick][fpsemigroup][kbp][finite]") {
+  std::vector<relation_t> rels = {
+      relation_t({0, 0}, {0}),
+      relation_t({0, 1}, {1}),
+      relation_t({1, 0}, {1}),
+      relation_t({0, 2}, {2}),
+      relation_t({2, 0}, {2}),
+      relation_t({0, 3}, {3}),
+      relation_t({3, 0}, {3}),
+      relation_t({0, 4}, {4}),
+      relation_t({4, 0}, {4}),
+      relation_t({1, 2}, {0}),
+      relation_t({2, 1}, {0}),
+      relation_t({3, 4}, {0}),
+      relation_t({4, 3}, {0}),
+      relation_t({2, 2}, {0}),
+      relation_t({1, 4, 2, 3, 3}, {0}),
+      relation_t({4, 4, 4}, {0})};
+  std::vector<relation_t> extra = {};
+
+  Congruence cong("twosided", 5, rels, extra);
+  cong.force_kbp();
+  cong.set_report(KBP_REPORT);
+
+  REQUIRE(cong.nr_classes() == 6);
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({2}));
+}
+
+TEST_CASE("KBP 10: finite fp-semigroup, size 16",
+          "[quick][fpsemigroup][kbp][finite]") {
+  std::vector<relation_t> rels = {
+      relation_t({3}, {2}),
+      relation_t({0, 3}, {0, 2}),
+      relation_t({1, 1}, {1}),
+      relation_t({1, 3}, {1, 2}),
+      relation_t({2, 1}, {2}),
+      relation_t({2, 2}, {2}),
+      relation_t({2, 3}, {2}),
+      relation_t({0, 0, 0}, {0}),
+      relation_t({0, 0, 1}, {1}),
+      relation_t({0, 0, 2}, {2}),
+      relation_t({0, 1, 2}, {1, 2}),
+      relation_t({1, 0, 0}, {1}),
+      relation_t({1, 0, 2}, {0, 2}),
+      relation_t({2, 0, 0}, {2}),
+      relation_t({0, 1, 0, 1}, {1, 0, 1}),
+      relation_t({0, 2, 0, 2}, {2, 0, 2}),
+      relation_t({1, 0, 1, 0}, {1, 0, 1}),
+      relation_t({1, 2, 0, 1}, {1, 0, 1}),
+      relation_t({1, 2, 0, 2}, {2, 0, 2}),
+      relation_t({2, 0, 1, 0}, {2, 0, 1}),
+      relation_t({2, 0, 2, 0}, {2, 0, 2})};
+  std::vector<relation_t> extra = {};
+
+  Congruence cong("twosided", 4, rels, extra);
+  cong.force_kbp();
+  cong.set_report(KBP_REPORT);
+
+  REQUIRE(cong.nr_classes() == 16);
+  REQUIRE(cong.word_to_class_index({2}) == cong.word_to_class_index({3}));
+}
+
+TEST_CASE("KBP 11: finite fp-semigroup, size 16",
+          "[quick][fpsemigroup][kbp][finite]") {
+  std::vector<relation_t> rels = {
+      relation_t({2}, {1}),
+      relation_t({4}, {3}),
+      relation_t({5}, {0}),
+      relation_t({6}, {3}),
+      relation_t({7}, {1}),
+      relation_t({8}, {3}),
+      relation_t({9}, {3}),
+      relation_t({10}, {0}),
+      relation_t({0, 2}, {0, 1}),
+      relation_t({0, 4}, {0, 3}),
+      relation_t({0, 5}, {0, 0}),
+      relation_t({0, 6}, {0, 3}),
+      relation_t({0, 7}, {0, 1}),
+      relation_t({0, 8}, {0, 3}),
+      relation_t({0, 9}, {0, 3}),
+      relation_t({0, 10}, {0, 0}),
+      relation_t({1, 1}, {1}),
+      relation_t({1, 2}, {1}),
+      relation_t({1, 4}, {1, 3}),
+      relation_t({1, 5}, {1, 0}),
+      relation_t({1, 6}, {1, 3}),
+      relation_t({1, 7}, {1}),
+      relation_t({1, 8}, {1, 3}),
+      relation_t({1, 9}, {1, 3}),
+      relation_t({1, 10}, {1, 0}),
+      relation_t({3, 1}, {3}),
+      relation_t({3, 2}, {3}),
+      relation_t({3, 3}, {3}),
+      relation_t({3, 4}, {3}),
+      relation_t({3, 5}, {3, 0}),
+      relation_t({3, 6}, {3}),
+      relation_t({3, 7}, {3}),
+      relation_t({3, 8}, {3}),
+      relation_t({3, 9}, {3}),
+      relation_t({3, 10}, {3, 0}),
+      relation_t({0, 0, 0}, {0}),
+      relation_t({0, 0, 1}, {1}),
+      relation_t({0, 0, 3}, {3}),
+      relation_t({0, 1, 3}, {1, 3}),
+      relation_t({1, 0, 0}, {1}),
+      relation_t({1, 0, 3}, {0, 3}),
+      relation_t({3, 0, 0}, {3}),
+      relation_t({0, 1, 0, 1}, {1, 0, 1}),
+      relation_t({0, 3, 0, 3}, {3, 0, 3}),
+      relation_t({1, 0, 1, 0}, {1, 0, 1}),
+      relation_t({1, 3, 0, 1}, {1, 0, 1}),
+      relation_t({1, 3, 0, 3}, {3, 0, 3}),
+      relation_t({3, 0, 1, 0}, {3, 0, 1}),
+      relation_t({3, 0, 3, 0}, {3, 0, 3})};
+  std::vector<relation_t> extra = {};
+
+  Congruence cong("twosided", 11, rels, extra);
+  cong.force_kbp();
+  cong.set_report(KBP_REPORT);
+
+  REQUIRE(cong.nr_classes() == 16);
+  REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({5}));
+  REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({10}));
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({2}));
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({7}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({4}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({6}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({8}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({9}));
+}

--- a/test/rwse.test.cc
+++ b/test/rwse.test.cc
@@ -58,7 +58,8 @@ TEST_CASE("RWSE 01:", "[quick][rwse]") {
 
   RWSE ab(rws, word_t({0, 1}));
   RWSE b(rws, 1);
-  REQUIRE(b < ab);
+  REQUIRE(!(b < ab));
+  REQUIRE(b == ab);
   REQUIRE(!(ab < b));
   ab.really_delete();
   b.really_delete();

--- a/test/tc.test.cc
+++ b/test/tc.test.cc
@@ -401,3 +401,136 @@ TEST_CASE("TC 11: right congruence on transformation semigroup size 88",
   delete t6;
   delete cong;
 }
+
+TEST_CASE("TC 12: finite fp-semigroup, dihedral group of order 6",
+          "[quick][fpsemigroup][tc][finite]") {
+  std::vector<relation_t> rels = {
+      relation_t({0, 0}, {0}),
+      relation_t({0, 1}, {1}),
+      relation_t({1, 0}, {1}),
+      relation_t({0, 2}, {2}),
+      relation_t({2, 0}, {2}),
+      relation_t({0, 3}, {3}),
+      relation_t({3, 0}, {3}),
+      relation_t({0, 4}, {4}),
+      relation_t({4, 0}, {4}),
+      relation_t({1, 2}, {0}),
+      relation_t({2, 1}, {0}),
+      relation_t({3, 4}, {0}),
+      relation_t({4, 3}, {0}),
+      relation_t({2, 2}, {0}),
+      relation_t({1, 4, 2, 3, 3}, {0}),
+      relation_t({4, 4, 4}, {0})};
+
+  std::vector<relation_t> extra = {};
+
+  Congruence cong("twosided", 5, rels, extra);
+  cong.force_tc();
+  cong.set_report(TC_REPORT);
+
+  REQUIRE(cong.nr_classes() == 6);
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({2}));
+}
+
+TEST_CASE("TC 13: finite fp-semigroup, size 16",
+          "[quick][fpsemigroup][tc][finite]") {
+  std::vector<relation_t> rels = {
+      relation_t({3}, {2}),
+      relation_t({0, 3}, {0, 2}),
+      relation_t({1, 1}, {1}),
+      relation_t({1, 3}, {1, 2}),
+      relation_t({2, 1}, {2}),
+      relation_t({2, 2}, {2}),
+      relation_t({2, 3}, {2}),
+      relation_t({0, 0, 0}, {0}),
+      relation_t({0, 0, 1}, {1}),
+      relation_t({0, 0, 2}, {2}),
+      relation_t({0, 1, 2}, {1, 2}),
+      relation_t({1, 0, 0}, {1}),
+      relation_t({1, 0, 2}, {0, 2}),
+      relation_t({2, 0, 0}, {2}),
+      relation_t({0, 1, 0, 1}, {1, 0, 1}),
+      relation_t({0, 2, 0, 2}, {2, 0, 2}),
+      relation_t({1, 0, 1, 0}, {1, 0, 1}),
+      relation_t({1, 2, 0, 1}, {1, 0, 1}),
+      relation_t({1, 2, 0, 2}, {2, 0, 2}),
+      relation_t({2, 0, 1, 0}, {2, 0, 1}),
+      relation_t({2, 0, 2, 0}, {2, 0, 2})};
+  std::vector<relation_t> extra = {};
+
+  Congruence cong("twosided", 4, rels, extra);
+  cong.force_tc();
+  cong.set_report(TC_REPORT);
+
+  REQUIRE(cong.nr_classes() == 16);
+  REQUIRE(cong.word_to_class_index({2}) == cong.word_to_class_index({3}));
+}
+
+TEST_CASE("TC 14: finite fp-semigroup, size 16",
+          "[quick][fpsemigroup][tc][finite]") {
+  std::vector<relation_t> rels = {
+      relation_t({2}, {1}),
+      relation_t({4}, {3}),
+      relation_t({5}, {0}),
+      relation_t({6}, {3}),
+      relation_t({7}, {1}),
+      relation_t({8}, {3}),
+      relation_t({9}, {3}),
+      relation_t({10}, {0}),
+      relation_t({0, 2}, {0, 1}),
+      relation_t({0, 4}, {0, 3}),
+      relation_t({0, 5}, {0, 0}),
+      relation_t({0, 6}, {0, 3}),
+      relation_t({0, 7}, {0, 1}),
+      relation_t({0, 8}, {0, 3}),
+      relation_t({0, 9}, {0, 3}),
+      relation_t({0, 10}, {0, 0}),
+      relation_t({1, 1}, {1}),
+      relation_t({1, 2}, {1}),
+      relation_t({1, 4}, {1, 3}),
+      relation_t({1, 5}, {1, 0}),
+      relation_t({1, 6}, {1, 3}),
+      relation_t({1, 7}, {1}),
+      relation_t({1, 8}, {1, 3}),
+      relation_t({1, 9}, {1, 3}),
+      relation_t({1, 10}, {1, 0}),
+      relation_t({3, 1}, {3}),
+      relation_t({3, 2}, {3}),
+      relation_t({3, 3}, {3}),
+      relation_t({3, 4}, {3}),
+      relation_t({3, 5}, {3, 0}),
+      relation_t({3, 6}, {3}),
+      relation_t({3, 7}, {3}),
+      relation_t({3, 8}, {3}),
+      relation_t({3, 9}, {3}),
+      relation_t({3, 10}, {3, 0}),
+      relation_t({0, 0, 0}, {0}),
+      relation_t({0, 0, 1}, {1}),
+      relation_t({0, 0, 3}, {3}),
+      relation_t({0, 1, 3}, {1, 3}),
+      relation_t({1, 0, 0}, {1}),
+      relation_t({1, 0, 3}, {0, 3}),
+      relation_t({3, 0, 0}, {3}),
+      relation_t({0, 1, 0, 1}, {1, 0, 1}),
+      relation_t({0, 3, 0, 3}, {3, 0, 3}),
+      relation_t({1, 0, 1, 0}, {1, 0, 1}),
+      relation_t({1, 3, 0, 1}, {1, 0, 1}),
+      relation_t({1, 3, 0, 3}, {3, 0, 3}),
+      relation_t({3, 0, 1, 0}, {3, 0, 1}),
+      relation_t({3, 0, 3, 0}, {3, 0, 3})};
+  std::vector<relation_t> extra = {};
+
+  Congruence cong("twosided", 11, rels, extra);
+  cong.force_tc();
+  cong.set_report(TC_REPORT);
+
+  REQUIRE(cong.nr_classes() == 16);
+  REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({5}));
+  REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({10}));
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({2}));
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({7}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({4}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({6}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({8}));
+  REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({9}));
+}


### PR DESCRIPTION
I've added some tests for finite fp-semigroups which have some generators that are equal. Currently Todd-Coxeter deals with these fine, but KBP and KBFP seem to assume that these generators are distinct, even though one can be reduced to the other by the rewriting system. In order words, Knuth-Bendix is currently assuming that generators are automatically reduced.

Note that these tests currently fail for KBP and KBFP.