### PR TITLE
Batch processing for congruences

### DIFF
--- a/cong.cc
+++ b/cong.cc
@@ -225,42 +225,44 @@ namespace libsemigroups {
     return winner;
   }
 
-  void Congruence::force_tc() {
+  void Congruence::clear_data() {
     if (_data != nullptr) {
       delete _data;
     }
+    if (!_partial_data.empty()) {
+      for (size_t i = 0; i < _partial_data.size(); i++) {
+        delete _partial_data.at(i);
+      }
+      _partial_data.clear();
+    }
+  }
+
+  void Congruence::force_tc() {
+    clear_data();
     _data = new TC(*this);
   }
 
   void Congruence::force_tc_prefill() {
-    if (_data != nullptr) {
-      delete _data;
-    }
+    clear_data();
     _data = new TC(*this);
     static_cast<TC*>(_data)->prefill();
   }
 
   void Congruence::force_p() {
-    if (_data != nullptr) {
-      delete _data;
-    }
     assert(_semigroup != nullptr);
+    clear_data();
     _data = new P(*this);
   }
 
   void Congruence::force_kbp() {
-    if (_data != nullptr) {
-      delete _data;
-    }
     assert(_semigroup == nullptr);
+    clear_data();
     _data = new KBP(*this);
   }
 
   void Congruence::force_kbfp() {
-    if (_data != nullptr) {
-      delete _data;
-    }
     assert(_type == TWOSIDED);
+    clear_data();
     _data = new KBFP(*this);
   }
 

--- a/cong.cc
+++ b/cong.cc
@@ -101,7 +101,7 @@ namespace libsemigroups {
         REPORT("allocation failed: " << e.what())
         return;
       }
-      if (data.at(pos)->is_done()) {
+      if (!data.at(pos)->is_killed()) {
         for (auto it = data.begin(); it < data.begin() + pos; it++) {
           (*it)->kill();
         }
@@ -131,7 +131,7 @@ namespace libsemigroups {
       t.at(i).join();
     }
     for (auto winner = data.begin(); winner < data.end(); winner++) {
-      if ((*winner)->is_done()) {
+      if (!(*winner)->is_killed()) {
         size_t tid = glob_reporter.thread_id(tids.at(winner - data.begin()));
         REPORT("Thread #" << tid << " is the winner!");
         for (auto loser = data.begin(); loser < winner; loser++) {

--- a/cong.cc
+++ b/cong.cc
@@ -29,8 +29,8 @@
 namespace libsemigroups {
 
   // Define static data members
-  size_t const Congruence::INFTY     = -1;
-  size_t const Congruence::UNDEFINED = -1;
+  size_t const Congruence::INFTY     = std::numeric_limits<size_t>::max();
+  size_t const Congruence::UNDEFINED = std::numeric_limits<size_t>::max();
 
   // Get the type from a string
   Congruence::cong_t Congruence::type_from_string(std::string type) {

--- a/cong.h
+++ b/cong.h
@@ -283,6 +283,11 @@ namespace libsemigroups {
     }
 
     // non-const
+    // This deletes all DATA objects stored in this congruence, including
+    // finished objects and partially-enumerated objects.
+    void clear_data();
+
+    // non-const
     // This forces the congruence to use the [Todd-Coxeter
     // algorithm](https://en.wikipedia.org/wiki/Todd–Coxeter_algorithm)
     // to compute the congruence. This is non-const because any existing data

--- a/cong.h
+++ b/cong.h
@@ -499,11 +499,6 @@ namespace libsemigroups {
         }
       }
 
-      // Compress the data structure, this does nothing by default, but
-      // rewriting systems and the Todd-Coxeter data structures can be
-      // compressed, to use less memory.
-      virtual void compress() {}
-
      private:
       // This initialises the data structure, and can be run from inside a
       // thread after construction.  If already initialised, this does nothing.

--- a/cong.h
+++ b/cong.h
@@ -404,6 +404,11 @@ namespace libsemigroups {
     }
 
     DATA* get_data();
+
+    DATA* cget_data() const {
+      return _data;
+    }
+
     DATA* winning_data(std::vector<DATA*>&                      data,
                        std::vector<std::function<void(DATA*)>>& funcs,
                        bool ignore_max_threads = false);

--- a/cong.h
+++ b/cong.h
@@ -407,6 +407,25 @@ namespace libsemigroups {
       // @return keeping cldoc happy
       virtual result_t current_equals(word_t const& w1, word_t const& w2) = 0;
 
+      // This method returns **TRUE** if the two words are known to be in
+      // distinct classes, where w1's class is less than w2's class by some
+      // total ordering; **FALSE** if this is known to be untrue; and
+      // **UNKNOWN** if the information has not yet been discovered.
+      // @w1 const reference to the first word
+      // @w2 const reference to the second word
+      //
+      // @return keeping cldoc happy
+      virtual result_t current_less_than(word_t const& w1, word_t const& w2) {
+        if (is_done()) {
+          return word_to_class_index(w1) < word_to_class_index(w2)
+                     ? result_t::TRUE
+                     : result_t::FALSE;
+        } else if (current_equals(w1, w2) == result_t::TRUE) {
+          return result_t::FALSE;  // elements are equal
+        }
+        return result_t::UNKNOWN;
+      }
+
       // This method returns the non-trivial classes of the congruence.
       //
       // @return keeping cldoc happy

--- a/cong.h
+++ b/cong.h
@@ -377,7 +377,7 @@ namespace libsemigroups {
       // This method can be used to tell whether or not a given DATA object has
       // been killed by another instance.
       // @return keeping cldoc happy
-      std::atomic<bool>& get_killed() {
+      std::atomic<bool>& is_killed() {
         return _killed;
       }
 

--- a/cong.h
+++ b/cong.h
@@ -368,6 +368,19 @@ namespace libsemigroups {
       // @return keeping cldoc happy
       virtual class_index_t word_to_class_index(word_t const& word) = 0;
 
+      // Possible result of questions that might not yet be answerable
+      enum result_t { TRUE = 0, FALSE = 1, UNKNOWN = 2 };
+
+      // This method returns **TRUE** if the two words are known to describe
+      // elements in the same congruence class, **FALSE** if they are known to
+      // lie in different classes, and **UNKNOWN** if the information has not
+      // yet been discovered.
+      // @w1 const reference to the first word
+      // @w2 const reference to the second word
+      //
+      // @return keeping cldoc happy
+      virtual result_t current_equals(word_t const& w1, word_t const& w2) = 0;
+
       // This method returns the non-trivial classes of the congruence.
       //
       // @return keeping cldoc happy

--- a/cong.h
+++ b/cong.h
@@ -340,8 +340,13 @@ namespace libsemigroups {
       virtual ~DATA() {}
 
       // This method runs the algorithm used to determine the congruence, i.e.
-      // Todd-Coxeter, Knuth-Bendix, etc
+      // Todd-Coxeter, Knuth-Bendix, etc., until completion
       virtual void run() = 0;
+
+      // This method runs the algorithm for a while, then stops after a certain
+      // amount of work or when done
+      // @steps the amount of work to do before returning
+      virtual void run(size_t steps) = 0;
 
       // This method returns true if a DATA object's run method has been run to
       // conclusion, i.e. that it has not been killed by another instance.

--- a/cong.h
+++ b/cong.h
@@ -463,6 +463,11 @@ namespace libsemigroups {
         _killed = true;
       }
 
+      // This method sets a given instance of a DATA object to "not killed"
+      void unkill() {
+        _killed = false;
+      }
+
       // This method can be used to tell whether or not a given DATA object has
       // been killed by another instance.
       // @return keeping cldoc happy
@@ -544,6 +549,7 @@ namespace libsemigroups {
     std::vector<relation_t> _extra;
     size_t                  _max_threads;
     size_t                  _nrgens;
+    std::vector<DATA*>      _partial_data;
     RecVec<class_index_t>   _prefill;
     std::vector<relation_t> _relations;
     std::atomic<bool>       _relations_done;

--- a/cong.h
+++ b/cong.h
@@ -153,13 +153,11 @@ namespace libsemigroups {
     //
     // @return **true** if the congruence is fully determined, and **false** if
     // it is not.
-    bool is_done() {
-      // FIXME this should really be const, but currently isn't because
-      // get_data isn't const
+    bool is_done() const {
       if (_data == nullptr) {
         return false;
       }
-      return get_data()->is_done();
+      return _data->is_done();
     }
 
     // non-const

--- a/cong.h
+++ b/cong.h
@@ -123,6 +123,32 @@ namespace libsemigroups {
     }
 
     // non-const
+    // @w1     a <word_t> in the (indices of) the generators of the semigroup
+    //         that **this** is defined over.
+    // @w2     a <word_t> in the (indices of) the generators of the semigroup
+    //         that **this** is defined over.
+    //
+    // This method is non-const because it may fully compute a data structure
+    // for the congruence.
+    //
+    // @return a bool describing whether the two words are in the same
+    //         equivalence class of this congruence
+    bool test_equals(word_t const& w1, word_t const& w2) {
+      DATA* data;
+      if (is_done()) {
+        data = cget_data();
+      } else {
+        std::function<bool(DATA*)> words_func = [&w1, &w2](DATA* data) {
+          return data->current_equals(w1, w2) != DATA::result_t::UNKNOWN;
+        };
+        data = get_data(words_func);
+      }
+      DATA::result_t result = data->current_equals(w1, w2);
+      assert(result != DATA::result_t::UNKNOWN);
+      return result == DATA::result_t::TRUE;
+    }
+
+    // non-const
     //
     // This method is non-const because it may fully compute a data structure
     // for the congruence.

--- a/cong.h
+++ b/cong.h
@@ -390,6 +390,10 @@ namespace libsemigroups {
       virtual void compress() {}
 
      private:
+      // This initialises the data structure, and can be run from inside a
+      // thread after construction.  If already initialised, this does nothing.
+      virtual void init() = 0;
+
       Congruence&                   _cong;
       std::atomic<bool>             _killed;
       size_t                        _report_interval;

--- a/cong.h
+++ b/cong.h
@@ -149,6 +149,32 @@ namespace libsemigroups {
     }
 
     // non-const
+    // @w1     a <word_t> in the (indices of) the generators of the semigroup
+    //         that **this** is defined over.
+    // @w2     a <word_t> in the (indices of) the generators of the semigroup
+    //         that **this** is defined over.
+    //
+    // This method is non-const because it may fully compute a data structure
+    // for the congruence.
+    //
+    // @return a bool describing whether the class of w1 is less than the class
+    //         of w2 in a total ordering of congruence classes
+    bool test_less_than(word_t const& w1, word_t const& w2) {
+      DATA* data;
+      if (is_done()) {
+        data = cget_data();
+      } else {
+        std::function<bool(DATA*)> words_func = [&w1, &w2](DATA* data) {
+          return data->current_less_than(w1, w2) != DATA::result_t::UNKNOWN;
+        };
+        data = get_data(words_func);
+      }
+      DATA::result_t result = data->current_less_than(w1, w2);
+      assert(result != DATA::result_t::UNKNOWN);
+      return result == DATA::result_t::TRUE;
+    }
+
+    // non-const
     //
     // This method is non-const because it may fully compute a data structure
     // for the congruence.

--- a/cong.h
+++ b/cong.h
@@ -118,9 +118,7 @@ namespace libsemigroups {
     // @return the index of the coset corresponding to <word>.
     class_index_t word_to_class_index(word_t const& word) {
       DATA* data = get_data();
-      if (!data->is_done()) {
-        data->run();
-      }
+      assert(data->is_done());
       return data->word_to_class_index(word);
     }
 
@@ -132,9 +130,7 @@ namespace libsemigroups {
     // @return the number of congruences classes (or cosets) of the congruence.
     size_t nr_classes() {
       DATA* data = get_data();
-      if (!data->is_done()) {
-        data->run();
-      }
+      assert(data->is_done());
       return data->nr_classes();
     }
 
@@ -148,9 +144,7 @@ namespace libsemigroups {
     // generators of the semigroup over which the congruence is defined.
     Partition<word_t> nontrivial_classes() {
       DATA* data = get_data();
-      if (!data->is_done()) {
-        data->run();
-      }
+      assert(data->is_done());
       return data->nontrivial_classes();
     }
 

--- a/cong/kbfp.cc
+++ b/cong/kbfp.cc
@@ -107,4 +107,14 @@ namespace libsemigroups {
                ? result_t::TRUE
                : result_t::FALSE;
   }
+
+  Congruence::DATA::result_t
+  Congruence::KBFP::current_less_than(word_t const& w1, word_t const& w2) {
+    init();
+    assert(_rws->is_confluent());
+    return _rws->test_less_than(RWS::word_to_rws_word(w1),
+                                RWS::word_to_rws_word(w2))
+               ? result_t::TRUE
+               : result_t::FALSE;
+  }
 }  // namespace libsemigroups

--- a/cong/kbfp.cc
+++ b/cong/kbfp.cc
@@ -37,7 +37,7 @@ namespace libsemigroups {
 
   void Congruence::KBFP::run() {
     while (!_killed && !is_done()) {
-      run(UINT_MAX);
+      run(Congruence::LIMIT_MAX);
     }
   }
 

--- a/cong/kbfp.cc
+++ b/cong/kbfp.cc
@@ -94,4 +94,17 @@ namespace libsemigroups {
     assert(pos != Semigroup::UNDEFINED);
     return pos;
   }
+
+  Congruence::DATA::result_t
+  Congruence::KBFP::current_equals(word_t const& w1, word_t const& w2) {
+    init();
+    if (is_killed()) {
+      return result_t::UNKNOWN;
+    }
+    assert(_rws->is_confluent());
+    return _rws->rewrite(RWS::word_to_rws_word(w1))
+                   == _rws->rewrite(RWS::word_to_rws_word(w2))
+               ? result_t::TRUE
+               : result_t::FALSE;
+  }
 }  // namespace libsemigroups

--- a/cong/kbfp.cc
+++ b/cong/kbfp.cc
@@ -36,6 +36,12 @@ namespace libsemigroups {
   }
 
   void Congruence::KBFP::run() {
+    while (!_killed && !is_done()) {
+      run(UINT_MAX);
+    }
+  }
+  
+  void Congruence::KBFP::run(size_t steps) {
     // Initialise the rewriting system
     _cong.init_relations(_cong._semigroup, _killed);
     _rws->add_rules(_cong.relations());
@@ -57,7 +63,7 @@ namespace libsemigroups {
 
       REPORT("running Froidure-Pin . . .")
 
-      _semigroup->enumerate(_killed, Semigroup::LIMIT_MAX);
+      _semigroup->enumerate(_killed, _semigroup->current_size() + steps);
     }
     if (_killed) {
       REPORT("killed")
@@ -66,9 +72,6 @@ namespace libsemigroups {
 
   Congruence::class_index_t
   Congruence::KBFP::word_to_class_index(word_t const& word) {
-    if (!is_done()) {
-      run();
-    }
     assert(is_done());  // so that _semigroup != nullptr
 
     Element* x   = new RWSE(*_rws, word);

--- a/cong/kbfp.h
+++ b/cong/kbfp.h
@@ -55,6 +55,7 @@ namespace libsemigroups {
 
     class_index_t word_to_class_index(word_t const& word) final;
     result_t current_equals(word_t const& w1, word_t const& w2) final;
+    result_t current_less_than(word_t const& w1, word_t const& w2) override;
 
     void compress() override {
       _rws->compress();

--- a/cong/kbfp.h
+++ b/cong/kbfp.h
@@ -54,6 +54,7 @@ namespace libsemigroups {
     }
 
     class_index_t word_to_class_index(word_t const& word) final;
+    result_t current_equals(word_t const& w1, word_t const& w2) final;
 
     void compress() override {
       _rws->compress();

--- a/cong/kbfp.h
+++ b/cong/kbfp.h
@@ -60,6 +60,8 @@ namespace libsemigroups {
     }
 
    private:
+    void init() final;
+
     RWS*       _rws;
     Semigroup* _semigroup;
   };

--- a/cong/kbfp.h
+++ b/cong/kbfp.h
@@ -34,7 +34,7 @@ namespace libsemigroups {
   class Congruence::KBFP : public Congruence::DATA {
    public:
     explicit KBFP(Congruence& cong)
-        : DATA(cong), _rws(new RWS()), _semigroup(nullptr) {}
+        : DATA(cong, 200), _rws(new RWS()), _semigroup(nullptr) {}
 
     ~KBFP() {
       delete _rws;

--- a/cong/kbfp.h
+++ b/cong/kbfp.h
@@ -57,10 +57,6 @@ namespace libsemigroups {
     result_t current_equals(word_t const& w1, word_t const& w2) final;
     result_t current_less_than(word_t const& w1, word_t const& w2) override;
 
-    void compress() override {
-      _rws->compress();
-    }
-
    private:
     void init() final;
 

--- a/cong/kbfp.h
+++ b/cong/kbfp.h
@@ -42,6 +42,7 @@ namespace libsemigroups {
     }
 
     void run() final;
+    void run(size_t steps) final;
 
     bool is_done() const final {
       return (_semigroup != nullptr && _semigroup->is_done());

--- a/cong/kbp.cc
+++ b/cong/kbp.cc
@@ -30,6 +30,12 @@
 namespace libsemigroups {
 
   void Congruence::KBP::run() {
+    while (!_killed && !is_done()) {
+      run(UINT_MAX);
+    }
+  }
+  
+  void Congruence::KBP::run(size_t steps) {
     // Initialise the rewriting system
     _rws->add_rules(_cong.relations());
     REPORT("running Knuth-Bendix . . .");
@@ -48,11 +54,19 @@ namespace libsemigroups {
       _P_cong->set_relations(_cong.relations());
       _P_cong->force_p();
 
-      // only need _semigroup here to know the generators, and how to hash
-      // things etc
+  void Congruence::KBP::run() {
+    while (!_killed && !is_done()) {
+      run(UINT_MAX);
+    }
+  }
+
+  void Congruence::KBP::run(size_t steps) {
+    init();
+    if (!_killed) {
       REPORT("running P . . .")
-      P* p = static_cast<P*>(_P_cong->get_data());
-      p->run(_killed);
+      P* p = static_cast<P*>(_P_cong->cget_data());
+      assert(p != nullptr);
+      p->run(steps, _killed);
     }
     if (_killed) {
       REPORT("killed")

--- a/cong/kbp.cc
+++ b/cong/kbp.cc
@@ -81,6 +81,16 @@ namespace libsemigroups {
     return _P_cong->word_to_class_index(word);
   }
 
+  Congruence::DATA::result_t Congruence::KBP::current_equals(word_t const& w1,
+                                                             word_t const& w2) {
+    init();
+    if (is_killed()) {
+      return result_t::UNKNOWN;
+    }
+    assert(_P_cong != nullptr);
+    return _P_cong->cget_data()->current_equals(w1, w2);
+  }
+
   Partition<word_t> Congruence::KBP::nontrivial_classes() {
     assert(is_done());
     return _P_cong->nontrivial_classes();

--- a/cong/kbp.cc
+++ b/cong/kbp.cc
@@ -58,7 +58,7 @@ namespace libsemigroups {
 
   void Congruence::KBP::run() {
     while (!_killed && !is_done()) {
-      run(UINT_MAX);
+      run(Congruence::LIMIT_MAX);
     }
   }
 

--- a/cong/kbp.cc
+++ b/cong/kbp.cc
@@ -29,18 +29,18 @@
 
 namespace libsemigroups {
 
-  void Congruence::KBP::run() {
-    while (!_killed && !is_done()) {
-      run(UINT_MAX);
+  void Congruence::KBP::init() {
+    if (_semigroup != nullptr) {
+      return;
     }
-  }
-  
-  void Congruence::KBP::run(size_t steps) {
+    assert(_P_cong == nullptr);
+
     // Initialise the rewriting system
     _rws->add_rules(_cong.relations());
     REPORT("running Knuth-Bendix . . .");
     _rws->knuth_bendix(_killed);
 
+    // Setup the P cong
     if (!_killed) {
       assert(_rws->is_confluent());
       std::vector<Element*> gens;
@@ -53,6 +53,8 @@ namespace libsemigroups {
       _P_cong = new Congruence(_cong._type, _semigroup, _cong._extra);
       _P_cong->set_relations(_cong.relations());
       _P_cong->force_p();
+    }
+  }
 
   void Congruence::KBP::run() {
     while (!_killed && !is_done()) {

--- a/cong/kbp.h
+++ b/cong/kbp.h
@@ -60,6 +60,7 @@ namespace libsemigroups {
     }
 
     class_index_t word_to_class_index(word_t const& word) final;
+    result_t current_equals(word_t const& w1, word_t const& w2) final;
 
     Partition<word_t> nontrivial_classes() final;
 

--- a/cong/kbp.h
+++ b/cong/kbp.h
@@ -66,10 +66,6 @@ namespace libsemigroups {
 
     void init() final;
 
-    void compress() override {
-      _rws->compress();
-    }
-
    private:
     RWS*        _rws;
     Semigroup*  _semigroup;

--- a/cong/kbp.h
+++ b/cong/kbp.h
@@ -44,6 +44,7 @@ namespace libsemigroups {
     }
 
     void run() final;
+    void run(size_t steps) final;
 
     bool is_done() const final {
       return (_semigroup != nullptr) && (_P_cong != nullptr)

--- a/cong/kbp.h
+++ b/cong/kbp.h
@@ -35,7 +35,10 @@ namespace libsemigroups {
   class Congruence::KBP : public Congruence::DATA {
    public:
     explicit KBP(Congruence& cong)
-        : DATA(cong), _rws(new RWS()), _semigroup(nullptr), _P_cong(nullptr) {}
+        : DATA(cong, 200),
+          _rws(new RWS()),
+          _semigroup(nullptr),
+          _P_cong(nullptr) {}
 
     ~KBP() {
       delete _rws;

--- a/cong/kbp.h
+++ b/cong/kbp.h
@@ -60,6 +60,8 @@ namespace libsemigroups {
 
     Partition<word_t> nontrivial_classes() final;
 
+    void init() final;
+
     void compress() override {
       _rws->compress();
     }

--- a/cong/p.cc
+++ b/cong/p.cc
@@ -269,6 +269,25 @@ namespace libsemigroups {
     return _class_lookup[ind_x];
   }
 
+  Congruence::DATA::result_t Congruence::P::current_equals(word_t const& w1,
+                                                           word_t const& w2) {
+    if (is_done()) {
+      return word_to_class_index(w1) == word_to_class_index(w2)
+                 ? result_t::TRUE
+                 : result_t::FALSE;
+    }
+    Element*  x     = _cong._semigroup->word_to_element(w1);
+    Element*  y     = _cong._semigroup->word_to_element(w2);
+    p_index_t ind_x = get_index(x);
+    p_index_t ind_y = get_index(y);
+    x->really_delete();
+    y->really_delete();
+    delete x;
+    delete y;
+    return _lookup.find(ind_x) == _lookup.find(ind_y) ? result_t::TRUE
+                                                      : result_t::UNKNOWN;
+  }
+
   Partition<word_t> Congruence::P::nontrivial_classes() {
     assert(is_done());
     assert(_reverse_map.size() >= _nr_nontrivial_elms);

--- a/cong/p.cc
+++ b/cong/p.cc
@@ -42,7 +42,7 @@ namespace libsemigroups {
         _map(),
         _map_next(0),
         _next_class(0),
-        _pairs_to_mult(new std::stack<p_pair_const_t>()),
+        _pairs_to_mult(new std::queue<p_pair_const_t>()),
         _reverse_map(),
         _tmp1(nullptr),
         _tmp2(nullptr) {
@@ -91,7 +91,7 @@ namespace libsemigroups {
     size_t tid = glob_reporter.thread_id(std::this_thread::get_id());
     while (!_pairs_to_mult->empty()) {
       // Get the next pair
-      p_pair_const_t current_pair = _pairs_to_mult->top();
+      p_pair_const_t current_pair = _pairs_to_mult->front();
 
       _pairs_to_mult->pop();
 

--- a/cong/p.cc
+++ b/cong/p.cc
@@ -71,7 +71,23 @@ namespace libsemigroups {
     }
   }
 
+  void Congruence::P::run() {
+    run(_killed);
+  }
+
   void Congruence::P::run(std::atomic<bool>& killed) {
+    while (!killed && !is_done()) {
+      run(UINT_MAX, killed);
+    }
+  }
+
+  // This cannot currently be tested
+  void Congruence::P::run(size_t steps) {
+    run(steps, _killed);
+  }
+
+  void Congruence::P::run(size_t steps, std::atomic<bool>& killed) {
+    REPORT("number of steps = " << steps);
     size_t tid = glob_reporter.thread_id(std::this_thread::get_id());
     while (!_pairs_to_mult->empty()) {
       // Get the next pair
@@ -111,8 +127,12 @@ namespace libsemigroups {
           killed = true;
           return;
         }
-      } else if (killed) {
+      }
+      if (killed) {
         REPORT("killed");
+        return;
+      }
+      if (--steps == 0) {
         return;
       }
     }

--- a/cong/p.cc
+++ b/cong/p.cc
@@ -34,7 +34,7 @@
 namespace libsemigroups {
 
   Congruence::P::P(Congruence& cong)
-      : DATA(cong, 40000),
+      : DATA(cong, 2000, 40000),
         _class_lookup(),
         _done(false),
         _found_pairs(new std::unordered_set<p_pair_const_t, PHash, PEqual>()),
@@ -77,7 +77,7 @@ namespace libsemigroups {
 
   void Congruence::P::run(std::atomic<bool>& killed) {
     while (!killed && !is_done()) {
-      run(UINT_MAX, killed);
+      run(Congruence::LIMIT_MAX, killed);
     }
   }
 

--- a/cong/p.h
+++ b/cong/p.h
@@ -61,6 +61,8 @@ namespace libsemigroups {
     void run(size_t steps, std::atomic<bool>& killed);
 
    private:
+    void init() final {}  // The constructor sets up everything
+
     struct PHash {
      public:
       size_t operator()(p_pair_const_t const& pair) const {

--- a/cong/p.h
+++ b/cong/p.h
@@ -52,6 +52,7 @@ namespace libsemigroups {
     size_t nr_classes() final;
 
     class_index_t word_to_class_index(word_t const& word) final;
+    result_t current_equals(word_t const& w1, word_t const& w2) final;
 
     Partition<word_t> nontrivial_classes() final;
 

--- a/cong/p.h
+++ b/cong/p.h
@@ -26,7 +26,7 @@
 #ifndef LIBSEMIGROUPS_CONG_P_H_
 #define LIBSEMIGROUPS_CONG_P_H_
 
-#include <stack>
+#include <queue>
 #include <utility>
 #include <vector>
 
@@ -94,7 +94,7 @@ namespace libsemigroups {
     class_index_t               _next_class;
     p_index_t                   _nr_nontrivial_classes;
     p_index_t                   _nr_nontrivial_elms;
-    std::stack<p_pair_const_t>* _pairs_to_mult;
+    std::queue<p_pair_const_t>* _pairs_to_mult;
     std::vector<Element const*> _reverse_map;
     Element*                    _tmp1;
     Element*                    _tmp2;

--- a/cong/p.h
+++ b/cong/p.h
@@ -55,10 +55,10 @@ namespace libsemigroups {
 
     Partition<word_t> nontrivial_classes() final;
 
-    void run() {
-      run(_killed);
-    }
+    void run() final;
+    void run(size_t steps) final;
     void run(std::atomic<bool>& killed);
+    void run(size_t steps, std::atomic<bool>& killed);
 
    private:
     struct PHash {

--- a/cong/tc.cc
+++ b/cong/tc.cc
@@ -295,8 +295,7 @@ namespace libsemigroups {
     class_index_t c = _id_coset;
     if (_cong._type == LEFT) {
       // Iterate in reverse order
-      for (auto rit = w.crbegin(); rit != w.crend() && c != UNDEFINED;
-           ++rit) {
+      for (auto rit = w.crbegin(); rit != w.crend() && c != UNDEFINED; ++rit) {
         c = _table.get(c, *rit);
       }
     } else {

--- a/cong/tc.cc
+++ b/cong/tc.cc
@@ -292,25 +292,49 @@ namespace libsemigroups {
 
   Congruence::class_index_t
   Congruence::TC::word_to_class_index(word_t const& w) {
-    assert(is_done());
     class_index_t c = _id_coset;
     if (_cong._type == LEFT) {
       // Iterate in reverse order
-      for (auto rit = w.crbegin(); rit != w.crend(); ++rit) {
+      for (auto rit = w.crbegin(); rit != w.crend() && c != UNDEFINED;
+           ++rit) {
         c = _table.get(c, *rit);
-        // assert(c != UNDEFINED);
       }
     } else {
       // Iterate in sequential order
-      for (auto it = w.cbegin(); it != w.cend(); ++it) {
+      for (auto it = w.cbegin(); it != w.cend() && c != UNDEFINED; ++it) {
         c = _table.get(c, *it);
-        // assert(c != UNDEFINED);
       }
     }
     // c in {1 .. n} (where 0 is the id coset)
-    assert(c < _active);
+    assert(c < _active || c == UNDEFINED);
     // Convert to {0 .. n-1}
-    return c - 1;
+    return (c == UNDEFINED ? c : c - 1);
+  }
+
+  Congruence::DATA::result_t Congruence::TC::current_equals(word_t const& w1,
+                                                            word_t const& w2) {
+    init();
+    if (is_killed()) {
+      return result_t::UNKNOWN;
+    }
+
+    class_index_t c1 = word_to_class_index(w1);
+    class_index_t c2 = word_to_class_index(w2);
+
+    if (c1 == UNDEFINED || c2 == UNDEFINED) {
+      return result_t::UNKNOWN;
+    }
+
+    // c in {1 .. n} (where 0 is the id coset)
+    assert(c1 < _active);
+    assert(c2 < _active);
+    if (c1 == c2) {
+      return result_t::TRUE;
+    } else if (is_done()) {
+      return result_t::FALSE;
+    } else {
+      return result_t::UNKNOWN;
+    }
   }
 
   // Create a new active coset for coset c to map to under generator a

--- a/cong/tc.cc
+++ b/cong/tc.cc
@@ -77,7 +77,7 @@ namespace libsemigroups {
   // Now the new preimage and all the old preimages are stored.
 
   Congruence::TC::TC(Congruence& cong)
-      : DATA(cong, 2000000),
+      : DATA(cong, 1000, 2000000),
         _active(1),
         _already_reported_killed(false),
         _bckwd(1, 0),
@@ -556,7 +556,7 @@ namespace libsemigroups {
   // Apply the Todd-Coxeter algorithm until the coset table is complete.
   void Congruence::TC::run() {
     while (!is_done()) {
-      run(UINT_MAX);
+      run(Congruence::LIMIT_MAX);
       TC_KILLED
     }
   }

--- a/cong/tc.cc
+++ b/cong/tc.cc
@@ -238,10 +238,9 @@ namespace libsemigroups {
 
   // compress the table
   void Congruence::TC::compress() {
+    assert(is_done());
     if (_is_compressed) {
       return;
-    } else if (!is_done()) {
-      run();
     }
     _is_compressed = true;
     if (_active == _table.nr_rows()) {

--- a/cong/tc.cc
+++ b/cong/tc.cc
@@ -99,6 +99,24 @@ namespace libsemigroups {
         _table(cong._nrgens, 1, UNDEFINED),
         _tc_done(false) {}
 
+  void Congruence::TC::init() {
+    if (_relations.empty() && _extra.empty()) {
+      // This is the first run
+      init_tc_relations();
+      TC_KILLED
+      // Apply each "extra" relation to the first coset only
+      for (relation_t const& rel : _extra) {
+        trace(_id_coset, rel);  // Allow new cosets
+        TC_KILLED
+      }
+      if (_relations.empty()) {
+        _tc_done = true;
+        compress();
+        return;
+      }
+    }
+  }
+
   void Congruence::TC::prefill() {
     Semigroup* semigroup = _cong._semigroup;
     if (semigroup == nullptr) {
@@ -545,26 +563,12 @@ namespace libsemigroups {
 
   // Apply the Todd-Coxeter algorithm for the specified number of iterations
   void Congruence::TC::run(size_t steps) {
-    // If we have already run this before, then we are done
     _steps = steps;
+
+    init();
+
     if (_tc_done || _is_compressed) {
       return;
-    }
-
-    if (_relations.empty() && _extra.empty()) {
-      // This is the first run
-      init_tc_relations();
-      TC_KILLED
-      // Apply each "extra" relation to the first coset only
-      for (relation_t const& rel : _extra) {
-        trace(_id_coset, rel);  // Allow new cosets
-        TC_KILLED
-      }
-      if (_relations.empty()) {
-        _tc_done = true;
-        compress();
-        return;
-      }
     }
 
     // Run a batch

--- a/cong/tc.cc
+++ b/cong/tc.cc
@@ -30,7 +30,8 @@
       _already_reported_killed = true; \
       REPORT("killed")                 \
     }                                  \
-    return;                            \
+    _stop_packing = true;              \
+    _steps        = 1;                 \
   }
 
 namespace libsemigroups {
@@ -103,11 +104,9 @@ namespace libsemigroups {
     if (_relations.empty() && _extra.empty()) {
       // This is the first run
       init_tc_relations();
-      TC_KILLED
       // Apply each "extra" relation to the first coset only
       for (relation_t const& rel : _extra) {
         trace(_id_coset, rel);  // Allow new cosets
-        TC_KILLED
       }
       if (_relations.empty()) {
         _tc_done = true;
@@ -216,7 +215,6 @@ namespace libsemigroups {
     // call relations() here so that we can pass _killed.
 
     _cong.init_relations(_cong._semigroup, _killed);
-    TC_KILLED
 
     // Must insert at _relations.end() since it might be non-empty
     _relations.insert(
@@ -228,7 +226,6 @@ namespace libsemigroups {
       case TWOSIDED:
         break;
       case LEFT:
-        TC_KILLED
         for (relation_t& rel : _relations) {
           std::reverse(rel.first.begin(), rel.first.end());
           std::reverse(rel.second.begin(), rel.second.end());
@@ -490,8 +487,6 @@ namespace libsemigroups {
   void Congruence::TC::trace(class_index_t const& c,
                              relation_t const&    rel,
                              bool                 add) {
-    TC_KILLED
-
     class_index_t lhs = c;
     for (auto it = rel.first.cbegin(); it < rel.first.cend() - 1; it++) {
       if (_table.get(lhs, *it) != UNDEFINED) {
@@ -515,7 +510,6 @@ namespace libsemigroups {
       } else {
         return;
       }
-      TC_KILLED
     }
     // <rhs> is the image of <c> under <rel>[2] (minus the last letter)
 
@@ -535,7 +529,6 @@ namespace libsemigroups {
       _report_next   = 0;
       _cosets_killed = _defined - _active;
     }
-    TC_KILLED
 
     letter_t      a = rel.first.back();
     letter_t      b = rel.second.back();
@@ -578,7 +571,7 @@ namespace libsemigroups {
 
   // Apply the Todd-Coxeter algorithm until the coset table is complete.
   void Congruence::TC::run() {
-    while (!is_done()) {
+    while (!is_done() && !is_killed()) {
       run(Congruence::LIMIT_MAX);
       TC_KILLED
     }

--- a/cong/tc.h
+++ b/cong/tc.h
@@ -58,6 +58,8 @@ namespace libsemigroups {
     void prefill(RecVec<class_index_t>& table);
 
    private:
+    void init() final;
+
     void init_after_prefill();
     void init_tc_relations();
 

--- a/cong/tc.h
+++ b/cong/tc.h
@@ -38,6 +38,7 @@ namespace libsemigroups {
     ~TC() {}
 
     void run() final;
+    void run(size_t steps) final;
 
     bool is_done() const final {
       return _tc_done;
@@ -85,9 +86,10 @@ namespace libsemigroups {
     RecVec<class_index_t>     _preim_next;
     std::vector<relation_t>   _relations;
     std::stack<class_index_t> _rhs_stack;     // Stack for identifying cosets
+    size_t                    _steps;
     size_t                    _stop_packing;  // TODO(JDM): make this a bool?
     RecVec<class_index_t>     _table;
-    bool                      _tc_done;  // Has todd_coxeter already been run?
+    bool                      _tc_done;  // Has Todd-Coxeter been completed?
   };
 }  // namespace libsemigroups
 #endif  // LIBSEMIGROUPS_CONG_TC_H_

--- a/cong/tc.h
+++ b/cong/tc.h
@@ -50,6 +50,7 @@ namespace libsemigroups {
     }
 
     class_index_t word_to_class_index(word_t const& word) final;
+    result_t current_equals(word_t const& w1, word_t const& w2) final;
 
     // This method compresses the coset table used by <todd_coxeter>.
     void compress();

--- a/elements.cc
+++ b/elements.cc
@@ -28,7 +28,7 @@
 
 namespace libsemigroups {
 
-  size_t const Element::UNDEFINED = -1;
+  size_t const Element::UNDEFINED = std::numeric_limits<size_t>::max();
 
   // BooleanMat
 
@@ -99,7 +99,8 @@ namespace libsemigroups {
 
   // Bipartition
 
-  u_int32_t const Bipartition::UNDEFINED = -1;
+  u_int32_t const Bipartition::UNDEFINED =
+      std::numeric_limits<u_int32_t>::max();
   std::vector<std::vector<u_int32_t>>
       Bipartition::_fuse(std::thread::hardware_concurrency());
   std::vector<std::vector<u_int32_t>>

--- a/partition.h
+++ b/partition.h
@@ -35,6 +35,8 @@ namespace libsemigroups {
   // pointers to which are stored in the partition.
 
   template <typename T> class Partition {
+    // TODO: do something else instead of using this object?
+
    public:
     // 1 parameters (size_t)
     // @nr_parts a size_t (defaults to 0)

--- a/rws.h
+++ b/rws.h
@@ -273,6 +273,21 @@ namespace libsemigroups {
     }
 
     // non-const
+    // @p      a word
+    // @q      a word
+    //
+    // @return **true** if the reduced form of the word <p> is less than
+    // the reduced form of the word <q>, with respect to the reduced ordering
+    // defined by this RWS; and **false** otherwise.
+    bool test_less_than(rws_word_t const& p, rws_word_t const& q) {
+      assert(_order != nullptr);
+      if (!is_confluent()) {
+        knuth_bendix();
+      }
+      return (*_order)(rewrite(q), rewrite(p));
+    }
+
+    // non-const
     // @killed an atomic boolean
     //
     // Run the [Knuth-Bendix

--- a/test/cong.test.cc
+++ b/test/cong.test.cc
@@ -723,4 +723,7 @@ TEST_CASE("Congruence 20: Infinite fp semigroup with infinite classes",
   REQUIRE(!cong.test_less_than(y, x));
 
   REQUIRE(!cong.is_done());
+
+  cong.force_kbfp();  // clear data
+  REQUIRE(cong.test_equals(x, y));
 }

--- a/test/cong.test.cc
+++ b/test/cong.test.cc
@@ -156,6 +156,8 @@ TEST_CASE("Congruence 06: 6-argument constructor (trivial cong)",
   Congruence              cong("twosided", &S, extra);
   cong.set_report(CONG_REPORT);
   REQUIRE(!cong.is_done());
+
+  REQUIRE(cong.nontrivial_classes().size() == 0);
 }
 
 TEST_CASE("Congruence 07: 6-argument constructor (nontrivial cong)",
@@ -726,4 +728,16 @@ TEST_CASE("Congruence 20: Infinite fp semigroup with infinite classes",
 
   cong.force_kbfp();  // clear data
   REQUIRE(cong.test_equals(x, y));
+}
+
+TEST_CASE("Congruence 21: trivial cong on an fp semigroup",
+          "[quick][congruence][fpsemigroup][multithread]") {
+  std::vector<relation_t> rels;
+  rels.push_back(relation_t({0, 0, 0}, {0}));  // (a^3, a)
+  rels.push_back(relation_t({0}, {1}));        // (a, b)
+  std::vector<relation_t> extra;
+
+  Congruence cong("left", 2, rels, extra);
+
+  REQUIRE(cong.nontrivial_classes().size() == 0);
 }

--- a/test/cong.test.cc
+++ b/test/cong.test.cc
@@ -258,6 +258,9 @@ TEST_CASE("Congruence 8L: left congruence on transformation semigroup size 88",
   REQUIRE(cong.test_equals({1, 0, 0, 1, 0, 1}, {0, 0, 1, 0, 0, 0, 1}));
   REQUIRE(!cong.test_equals({1, 0, 0, 0, 1, 0, 0, 0}, {1, 0, 0, 1}));
 
+  REQUIRE(!cong.test_less_than({1, 0, 0, 0, 1, 0, 0, 0}, {1, 0, 0, 1}));
+  REQUIRE(cong.test_less_than({1, 0, 0, 1}, {1, 0, 0, 0, 1, 0, 0, 0}));
+
   t3->really_delete();
   t4->really_delete();
   delete t3;
@@ -367,6 +370,8 @@ TEST_CASE("Congruence 10: for an infinite fp semigroup",
 
   REQUIRE(cong.test_equals({1}, {1, 1}));
   REQUIRE(cong.test_equals({1, 0, 1}, {1, 0}));
+
+  REQUIRE(!cong.test_less_than({1, 0, 1}, {1, 0}));
 }
 
 TEST_CASE("Congruence 11: congruence on big finite semigroup",
@@ -412,6 +417,9 @@ TEST_CASE("Congruence 11: congruence on big finite semigroup",
 
   REQUIRE(cong.test_equals({1, 2, 1, 3, 3, 2, 1, 2}, {2, 1, 3, 3, 2, 1, 0}));
   REQUIRE(!cong.test_equals({1, 1, 0}, {1, 3, 3, 2, 2, 1, 0}));
+
+  REQUIRE(cong.test_less_than({1, 3, 3, 2, 2, 1, 0}, {1, 1, 0}));
+  REQUIRE(!cong.test_less_than({1, 1, 0, 0}, {0, 0, 3}));
 
   REQUIRE(cong.nr_classes() == 525);
   REQUIRE(cong.nr_classes() == 525);

--- a/test/cong.test.cc
+++ b/test/cong.test.cc
@@ -703,3 +703,24 @@ TEST_CASE("Congruence 19: Infinite fp semigroup from GAP library",
 
   REQUIRE(cong.is_done());
 }
+
+TEST_CASE("Congruence 20: Infinite fp semigroup with infinite classes",
+          "[quick][congruence][fpsemigroup][multithread]") {
+  std::vector<relation_t> rels = {relation_t({0, 0, 0}, {0}),
+                                  relation_t({0, 1}, {1, 0})};
+  std::vector<relation_t> extra = {relation_t({0}, {0, 0})};
+  Congruence              cong("twosided", 2, rels, extra);
+  cong.set_report(CONG_REPORT);
+
+  word_t x = {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  word_t y = {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+  REQUIRE(cong.test_equals(x, y));
+
+  REQUIRE(cong.test_less_than({0, 0, 0}, {1}));
+  REQUIRE(!cong.test_less_than({1}, {0, 0, 0}));
+  REQUIRE(!cong.test_less_than(x, y));
+  REQUIRE(!cong.test_less_than(y, x));
+
+  REQUIRE(!cong.is_done());
+}

--- a/test/cong.test.cc
+++ b/test/cong.test.cc
@@ -58,11 +58,15 @@ TEST_CASE("Congruence 01: Small fp semigroup",
 
   REQUIRE(cong.word_to_class_index({0, 0, 1})
           == cong.word_to_class_index({0, 0, 0, 0, 1}));
+  REQUIRE(cong.test_equals({0, 0, 1}, {0, 0, 0, 0, 1}));
   REQUIRE(cong.word_to_class_index({0, 0, 0, 0, 1})
           == cong.word_to_class_index({0, 1, 1, 0, 0, 1}));
+  REQUIRE(cong.test_equals({0, 0, 0, 0, 1}, {0, 1, 1, 0, 0, 1}));
   REQUIRE(cong.word_to_class_index({0, 0, 0})
           != cong.word_to_class_index({0, 0, 1}));
+  REQUIRE(!cong.test_equals({0, 0, 0}, {0, 0, 1}));
   REQUIRE(cong.word_to_class_index({1}) != cong.word_to_class_index({0, 0, 0}));
+  REQUIRE(!cong.test_equals({1}, {0, 0, 0}));
 }
 
 TEST_CASE("Congruence 02: Small left congruence on free semigroup",
@@ -103,14 +107,12 @@ TEST_CASE(
 
   REQUIRE(cong.word_to_class_index({0, 0, 1})
           == cong.word_to_class_index({0, 0, 0, 0, 1}));
-  REQUIRE(cong.word_to_class_index({0, 1, 1, 0, 0, 1})
-          == cong.word_to_class_index({0, 0, 1}));
+  REQUIRE(cong.test_equals({0, 1, 1, 0, 0, 1}, {0, 0, 1}));
   REQUIRE(cong.word_to_class_index({0, 0, 0})
           != cong.word_to_class_index({0, 0, 1}));
   REQUIRE(cong.word_to_class_index({1})
           != cong.word_to_class_index({0, 0, 0, 0}));
-  REQUIRE(cong.word_to_class_index({0, 0, 0, 0})
-          != cong.word_to_class_index({0, 0, 1}));
+  REQUIRE(!cong.test_equals({0, 0, 0, 0}, {0, 0, 1}));
 }
 
 TEST_CASE("Congruence 05: word_to_class_index for small fp semigroup",
@@ -136,8 +138,7 @@ TEST_CASE("Congruence 05: word_to_class_index for small fp semigroup",
 
   REQUIRE(cong2.word_to_class_index({0, 0, 0, 0})
           == cong2.word_to_class_index({0, 0}));
-  REQUIRE(cong2.word_to_class_index({0, 0, 0, 0})
-          == cong2.word_to_class_index({0, 1, 1, 0, 1, 1}));
+  REQUIRE(cong2.test_equals({0, 0, 0, 0}, {0, 1, 1, 0, 1, 1}));
 }
 
 TEST_CASE("Congruence 06: 6-argument constructor (trivial cong)",
@@ -209,6 +210,7 @@ TEST_CASE("Congruence 8T: transformation semigroup size 88",
   S.factorisation(w3, S.position(t3));
   S.factorisation(w4, S.position(t4));
   REQUIRE(cong.word_to_class_index(w3) == cong.word_to_class_index(w4));
+  REQUIRE(cong.test_equals(w3, w4));
 
   t1->really_delete();
   t2->really_delete();
@@ -253,6 +255,9 @@ TEST_CASE("Congruence 8L: left congruence on transformation semigroup size 88",
   REQUIRE(cong.word_to_class_index({1, 0, 0, 0, 1, 0, 0, 0})
           != cong.word_to_class_index({1, 0, 0, 1}));
 
+  REQUIRE(cong.test_equals({1, 0, 0, 1, 0, 1}, {0, 0, 1, 0, 0, 0, 1}));
+  REQUIRE(!cong.test_equals({1, 0, 0, 0, 1, 0, 0, 0}, {1, 0, 0, 1}));
+
   t3->really_delete();
   t4->really_delete();
   delete t3;
@@ -295,6 +300,10 @@ TEST_CASE("Congruence 8R: right congruence on transformation semigroup size 88",
   REQUIRE(cong.word_to_class_index(w5) == cong.word_to_class_index(w6));
   REQUIRE(cong.word_to_class_index(w3) != cong.word_to_class_index(w6));
 
+  REQUIRE(cong.test_equals(w1, w2));
+  REQUIRE(cong.test_equals(w5, w6));
+  REQUIRE(!cong.test_equals(w3, w5));
+
   t1->really_delete();
   t2->really_delete();
   t3->really_delete();
@@ -329,6 +338,9 @@ TEST_CASE("Congruence 09: for an infinite fp semigroup",
   REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({1, 0}));
   REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({1, 1}));
   REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({1, 0, 1}));
+
+  REQUIRE(cong.test_equals({1}, {1, 1}));
+  REQUIRE(cong.test_equals({1, 0, 1}, {1, 0}));
 }
 
 TEST_CASE("Congruence 10: for an infinite fp semigroup",
@@ -352,6 +364,9 @@ TEST_CASE("Congruence 10: for an infinite fp semigroup",
   REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({1, 0}));
   REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({1, 1}));
   REQUIRE(cong.word_to_class_index({0}) == cong.word_to_class_index({1, 0, 1}));
+
+  REQUIRE(cong.test_equals({1}, {1, 1}));
+  REQUIRE(cong.test_equals({1, 0, 1}, {1, 0}));
 }
 
 TEST_CASE("Congruence 11: congruence on big finite semigroup",
@@ -394,6 +409,9 @@ TEST_CASE("Congruence 11: congruence on big finite semigroup",
           != cong.word_to_class_index({0, 0, 3}));
   REQUIRE(cong.word_to_class_index({1, 1, 0})
           != cong.word_to_class_index({1, 3, 3, 2, 2, 1, 0}));
+
+  REQUIRE(cong.test_equals({1, 2, 1, 3, 3, 2, 1, 2}, {2, 1, 3, 3, 2, 1, 0}));
+  REQUIRE(!cong.test_equals({1, 1, 0}, {1, 3, 3, 2, 2, 1, 0}));
 
   REQUIRE(cong.nr_classes() == 525);
   REQUIRE(cong.nr_classes() == 525);
@@ -500,6 +518,7 @@ TEST_CASE("Congruence 14: Bicyclic monoid",
           == cong.word_to_class_index({1, 0, 2, 0, 1, 2}));
   REQUIRE(cong.word_to_class_index({2, 1})
           == cong.word_to_class_index({1, 2, 0, 2, 1, 1, 2}));
+  REQUIRE(cong.test_equals({2, 1}, {1, 2, 0, 2, 1, 1, 2}));
 }
 
 TEST_CASE("Congruence 15: Congruence on bicyclic monoid",

--- a/test/kbp.test.cc
+++ b/test/kbp.test.cc
@@ -116,6 +116,9 @@ TEST_CASE("KBP 03: for an infinite fp semigroup",
   Partition<word_t> nontrivial_classes = cong.nontrivial_classes();
   REQUIRE(nontrivial_classes.size() == 1);
   REQUIRE(nontrivial_classes[0]->size() == 2);
+
+  cong.force_kbp();  // clear data
+  REQUIRE(cong.word_to_class_index({1}) == cong.word_to_class_index({2}));
 }
 
 TEST_CASE("KBP 04: for an infinite fp semigroup",

--- a/test/kbp.test.cc
+++ b/test/kbp.test.cc
@@ -429,3 +429,20 @@ TEST_CASE("KBP 11: finite fp-semigroup, size 16",
   REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({8}));
   REQUIRE(cong.word_to_class_index({3}) == cong.word_to_class_index({9}));
 }
+
+TEST_CASE("KBP 12: Infinite fp semigroup with infinite classes",
+          "[quick][congruence][fpsemigroup][kbp]") {
+  std::vector<relation_t> rels = {relation_t({0, 0, 0}, {0}),
+                                  relation_t({0, 1}, {1, 0})};
+  std::vector<relation_t> extra = {relation_t({0}, {0, 0})};
+  Congruence              cong("twosided", 2, rels, extra);
+  cong.force_kbp();
+  cong.set_report(KBP_REPORT);
+
+  word_t x = {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  word_t y = {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+  REQUIRE(cong.test_equals(x, y));
+
+  REQUIRE(!cong.is_done());
+}

--- a/test/rws.test.cc
+++ b/test/rws.test.cc
@@ -510,6 +510,14 @@ TEST_CASE("RWS 25: Chapter 11, Section 1 (q = 4, r = 3) in NR",
   REQUIRE(rws.rewrite("bbbbaabbbbaa") == rws.rewrite("bbbbaa"));
   REQUIRE(rws.rewrite("bbbaa") == rws.rewrite("baabb"));
   REQUIRE(rws.rewrite("abbbaabbba") == rws.rewrite("bbbbaa"));
+
+  REQUIRE(!rws.test_less_than("abbbaabbba", "bbbbaa"));
+  REQUIRE(!rws.test_less_than("abba", "abba"));
+
+  // Call test_less_than without knuth_bendix first
+  RWS rws2(rules);
+  rws2.set_report(RWS_REPORT);
+  REQUIRE(!rws2.test_less_than("abbbaabbba", "bbbbaa"));
 }
 
 TEST_CASE("RWS 26: Chapter 11, Section 1 (q = 8, r = 5) in NR",
@@ -541,6 +549,8 @@ TEST_CASE("RWS 26: Chapter 11, Section 1 (q = 8, r = 5) in NR",
   REQUIRE(rws.rewrite("bbbbbbbbaabbbbbbbbaa") == rws.rewrite("bbbbbbbbaa"));
   REQUIRE(rws.rewrite("bbbaa") == rws.rewrite("baabb"));
   REQUIRE(rws.rewrite("abbbbbaabbbbba") == rws.rewrite("bbbbbbbbaa"));
+
+  REQUIRE(rws.test_less_than("aaa", "bbbbbbbbb"));
 }
 
 TEST_CASE("RWS 27: Chapter 11, Lemma 1.8 (q = 6, r = 5) in NR",
@@ -595,4 +605,7 @@ TEST_CASE("RWS 28: Chapter 8, Theorem 4.2 in NR", "[rws][quick][fpsemigroup]") {
   rws.knuth_bendix();
   REQUIRE(rws.nr_rules() == 8);
   REQUIRE(rws.is_confluent());
+
+  REQUIRE(!rws.test_less_than("bababababab", "aaaaa"));
+  REQUIRE(rws.test_less_than("aaaaa", "bababababab"));
 }


### PR DESCRIPTION
This PR allows a congruence to be run "a bit at a time", allowing us to answer whether two elements are in the same class without running to completion.  In particular, this allows us to say whether two elements are related even for congruences with an infinite number of pairs.

This has required quite a lot of changes, since we need to do some things quite differently.  When reviewing, I recommend looking through the changes one commit at a time, from the start - this should make it a bit more understandable.