### PR TITLE
Make nontrivial_classes use KBP for an fp congruence

### DIFF
--- a/cong.h
+++ b/cong.h
@@ -241,11 +241,7 @@ namespace libsemigroups {
     //! \warning If \c this has infinitely many non-trivial congruence classes,
     //! then this method will only terminate when it can no longer allocate
     //! memory.
-    Partition<word_t> nontrivial_classes() {
-      DATA* data = get_data();
-      assert(data->is_done());
-      return data->nontrivial_classes();
-    }
+    Partition<word_t> nontrivial_classes();
 
     //! Returns \c true if the structure of the congruence is known.
     bool is_done() const {

--- a/test/cong.test.cc
+++ b/test/cong.test.cc
@@ -758,8 +758,7 @@ TEST_CASE("Congruence 22: duplicate generators on a finite semigroup",
   REQUIRE(cong.nr_classes() == S.size());
 }
 
-// FIXME the following test should run, and does not.
-/*TEST_CASE("Congruence 23: test nontrivial_classes for a fp semigroup cong",
+TEST_CASE("Congruence 23: test nontrivial_classes for a fp semigroup cong",
           "[quick][congruence][finite][fpsemigroup]") {
   std::vector<relation_t> rels
       = {relation_t({0, 0, 0}, {0}),
@@ -781,4 +780,4 @@ TEST_CASE("Congruence 22: duplicate generators on a finite semigroup",
       "twosided", 2, rels, std::vector<relation_t>({relation_t({0}, {1})}));
   cong.set_report(CONG_REPORT);
   REQUIRE(cong.nontrivial_classes().size() == 1);
-}*/
+}


### PR DESCRIPTION
KBP is the only `DATA` which gives a meaningful answer for `nontrivial_classes`.  Hence, we should use KBP whenever `nontrivial-classes` is asked for.

This fixes @james-d-mitchell's segfaulting test.