### PR TITLE
tc: in init, only set _tc_done to true if not killed

### DIFF
--- a/src/cong/tc.cc
+++ b/src/cong/tc.cc
@@ -104,12 +104,10 @@ namespace libsemigroups {
       // This is the first run
       init_tc_relations();
       // Apply each "extra" relation to the first coset only
-      // FIXME couldn't we be prefilled here, in which case the next line
-      // performs a potentially costly computation
       for (relation_t const& rel : _extra) {
         trace(_id_coset, rel);  // Allow new cosets
       }
-      if (_relations.empty()) {
+      if (_relations.empty() && !_killed) {
         _tc_done = true;
         compress();
         return;

--- a/test/cong.test.cc
+++ b/test/cong.test.cc
@@ -792,3 +792,51 @@ TEST_CASE("Congruence 23: test nontrivial_classes for a fp semigroup cong",
   REQUIRE(ntc->size() == 1);
   delete ntc;
 }
+
+TEST_CASE("Congruence 24: example from GAP which once messed up prefill",
+          "[standard][congruence][multithread]") {
+  std::vector<Element*> gens = {
+    new Transformation<u_int16_t>({0, 1, 2, 3, 4, 5, 6, 7}),
+    new Transformation<u_int16_t>({1, 2, 3, 4, 5, 0, 6, 7}),
+    new Transformation<u_int16_t>({1, 0, 2, 3, 4, 5, 6, 7}),
+    new Transformation<u_int16_t>({0, 1, 2, 3, 4, 0, 6, 7}),
+    new Transformation<u_int16_t>({0, 1, 2, 3, 4, 5, 7, 6})
+  };
+  Semigroup S = Semigroup(gens);
+  S.set_report(CONG_REPORT);
+  really_delete_cont(gens);
+
+  std::vector<Element*> elms = {
+    new Transformation<u_int16_t>({0, 0, 0, 0, 0, 0, 7, 6}),
+    new Transformation<u_int16_t>({0, 0, 0, 0, 0, 0, 6, 7}),
+    new Transformation<u_int16_t>({0, 0, 0, 0, 0, 0, 6, 7}),
+    new Transformation<u_int16_t>({1, 1, 1, 1, 1, 1, 6, 7}),
+    new Transformation<u_int16_t>({0, 0, 0, 0, 0, 0, 6, 7}),
+    new Transformation<u_int16_t>({2, 2, 2, 2, 2, 2, 6, 7}),
+    new Transformation<u_int16_t>({0, 0, 0, 0, 0, 0, 6, 7}),
+    new Transformation<u_int16_t>({3, 3, 3, 3, 3, 3, 6, 7}),
+    new Transformation<u_int16_t>({0, 0, 0, 0, 0, 0, 6, 7}),
+    new Transformation<u_int16_t>({4, 4, 4, 4, 4, 4, 6, 7}),
+    new Transformation<u_int16_t>({0, 0, 0, 0, 0, 0, 6, 7}),
+    new Transformation<u_int16_t>({5, 5, 5, 5, 5, 5, 6, 7}),
+    new Transformation<u_int16_t>({0, 0, 0, 0, 0, 0, 7, 6}),
+    new Transformation<u_int16_t>({0, 1, 2, 3, 4, 5, 7, 6})
+  };
+
+  std::vector<relation_t> extra;
+  word_t   w1, w2;
+  for (size_t i = 0; i < elms.size(); i += 2) {
+    S.factorisation(w1, S.position(elms[i]));
+    S.factorisation(w2, S.position(elms[i + 1]));
+    extra.push_back(std::make_pair(w1, w2));
+    elms[i]->really_delete();
+    elms[i + 1]->really_delete();
+    delete elms[i];
+    delete elms[i + 1];
+  }
+
+  Congruence cong("right", &S, extra);
+  cong.set_report(CONG_REPORT);
+
+  REQUIRE(cong.nr_classes() == 1);
+}


### PR DESCRIPTION
This PR fixes the issue exposed by commit `668d6ea`, which is causing [the current Semigroups build to fail](https://travis-ci.org/gap-packages/Semigroups/jobs/223708980).

If a TC object was killed while prefilling, it might have empty relations during `init()`.  But this doesn't mean it's done.  We should only allow it to set _tc_done to true if it hasn't already been killed.

I also removed a FIXME: even if we are prefilled here, we still always need to apply the "extra" relations.