### PR TITLE
Add support for finitely presented semigroups

### DIFF
--- a/python-bindings/semigroups.pyx
+++ b/python-bindings/semigroups.pyx
@@ -744,6 +744,8 @@ cdef class FpSemigroup(Semigroup):
         for i in xrange(len(word)):
             word[i]=self.alphabet().index(word[i])
 
+
+
         cdef vector[uint64_t] Word = word
         return self._congruence.word_to_class_index(Word)
 
@@ -924,7 +926,6 @@ cdef class FpMonoid(FpSemigroup):
         self._e_relations = rels + [[[0,0],[0]]] + lefteq + righteq
         self._congruence = new cpp.Congruence(self._cong,self._size + 1,
                                                 self._e_relations,self._extra)
-
 
     def alphabet(self):
         '''
@@ -1135,6 +1136,36 @@ cdef class FpSemigroupElement(Element):
             return self.semigroup().word_to_class_index(FpSemigroupElement(
                             self.semigroup(),self.word() + other.word()))
 
+    def word_to_class_index(self):
+        '''
+        returns the class index of self
+
+        Examples:
+        >>> FpMonoid(["a","b"],[["aa","a"],["bbb","b"],["ab","ba"]])
+        <FpMonoid <a,b|aa=a,bbb=b,ab=ba>>
+        >>> E=FpMonoidElement(_,"")
+        >>> E.word_to_class_index()
+        0
+        >>> A=FpMonoidElement(E.monoid(),"a")
+        >>> A.word_to_class_index()
+        1
+        >>> B=FpMonoidElement(E.monoid(),"b")
+        >>> B.word_to_class_index()
+        2
+
+        Args:
+            None.
+
+        Returns:
+            int: class index of self.
+
+        Raises:
+            None.
+
+        '''
+
+        return self.semigroup().word_to_class_index(self)
+
     def __repr__(self):
         '''
         displays the FpSemigroup element
@@ -1228,15 +1259,21 @@ cdef class FpMonoidElement(FpSemigroupElement):
                 raise ValueError("given word is not in the given FpMonoid")
 
         if self._FpS._is_string_alphabet:
-            if word =="":
-                self._Word ="e".encode('UTF-8')
+            if word == []:
+                raise ValueError("given word is not in the given FpMonoid")
             else:
-                self._Word = word.encode('UTF-8')
+                if word =="":
+                    self._Word ="e".encode('UTF-8')
+                else:
+                    self._Word = word.encode('UTF-8')
         else:
             if word =="":
-                self._Word ="0".encode('UTF-8')
+                raise ValueError("given word is not in the given FpMonoid")
             else:
-                self._Word = str(word).encode('UTF-8')
+                if word == []:
+                    self._Word ="[0]".encode('UTF-8')
+                else:
+                    self._Word = str(word).encode('UTF-8')
 
 
     def monoid(self):

--- a/python-bindings/semigroups.pyx
+++ b/python-bindings/semigroups.pyx
@@ -24,6 +24,10 @@ from libc.stdint cimport uint16_t
 from libcpp.vector cimport vector
 cimport semigroups_cpp as cpp
 from libcpp cimport bool
+from libcpp.string cimport string
+from libcpp.pair cimport pair
+from libc.stdint cimport uint32_t
+from libc.stdint cimport uint64_t
 
 #cdef class MyCppElement(cpp.Element):
 #    pass
@@ -412,4 +416,875 @@ def FullTransformationMonoid(n):
     return Semigroup([Transformation([1, 0] + list(range(2, n))), 
                       Transformation([0, 0] + list(range(2, n))), 
                       Transformation([n - 1] + list(range(n - 1)))])
+
+cdef class FpSemigroup:
+    """FpSemigroup Object
+
+    Examples:
+        >>> FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"],["ab","ba"]])
+        <Fpsemigroup <a,b|aa=a,bbb=ab,ab=ba>>
+        >>> FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[1,2]],[[1,2],[2,1]]])
+        <Fpsemigroup <1,2|11=1,222=12,12=21>>
+
+    Todo:
+         write == method  
+         write normal_form method
+         add link to documentation for functions when it becomes available.
+    """    
+
+    cdef cpp.Congruence* _congruence
+
+    cdef cpp.RWS* _rws
+    
+    #list of single character strings which store the alphabet
+    #(even if using integer notation)
+    cdef vector[string] _alphabet
+
+    cdef vector[pair[vector[uint64_t],vector[uint64_t]]] _relations
+
+    #a vector of relations used to define a congruence
+    cdef vector[pair[vector[uint64_t],vector[uint64_t]]] _extra
+
+    #a boolean which is true when string notation is used for words 
+    #and false when integer notation is used for words
+    cdef bool _is_string_alphabet
+
+    cdef size_t _size 
+    
+    #a string containing "twosided" which is used to define a congruence
+    cdef string _cong
+
+    def __init__(self, alphabet, rels):
+        '''
+        Construct an FpSemigroup from generators and relations.
+        
+        Args:
+            alphabet (list): the generators of the fp semigroup, must be 
+            either a list of ints or a list of strings of length 1.
+
+            rels (list): the relations containing pairs of words which are
+            equivalent in the given FpSemigroup, must be a list of length 2 
+            lists of lists of ints or a list of length 2 lists of strings.
+
+        Returns:
+            None.
+
+        Raises:
+            TypeError: If the alphabet is not a list of integers or strings,
+            if the relations are not a double nested list of integers or a
+            nested list strings.
+
+            ValueError: If the alphabet contains repeated elements, if any of
+            the lists which are supposed to contain pairs of words don't 
+            contain 2 elements or any of the words in relations use generators
+            not in the given alphabet.
+        '''
+        if not isinstance(alphabet,list):
+            raise TypeError("alphabet should be a list")
+        self._size = len(alphabet)
+        self._cong = "twosided"
+        
+        # Checks if semigroup is empty.
+        if self._size > 0:
+            if not(isinstance(alphabet[0],int) or isinstance(alphabet[0],str)):
+                raise TypeError("alphabet should contain characters or ints")
+            self._is_string_alphabet = isinstance(alphabet[0],str)
+
+            # Check that the alphabet does not contain duplicates.
+            for i in alphabet:
+                if not alphabet.count(i)==1:
+                    raise ValueError("alphabet elements shouldn't be repeated")
+
+            if not isinstance(rels,list):
+                raise TypeError("relations should be stored n a list")
+
+            if self._is_string_alphabet:
+                for i in xrange(len(rels)):
+                    if not isinstance(rels[i],list):
+                        raise TypeError("each relation should"+ 
+                                        " be a pair of lists")
+
+                    if not len(rels[i]) == 2:
+                        raise ValueError("each relation should "+ 
+                                         "be a pair of lists")
+
+                    for j in [0,1]:
+                        if not isinstance(rels[i][j],str):
+                            raise TypeError("if alphabet contains characters"+
+                                  " then relations should be pairs of strings")
+                        rels[i][j] = list(rels[i][j])
+                        for k in xrange(len(rels[i][j])):
+                            if not rels[i][j][k] in alphabet:
+                                raise ValueError("elements referenced in "+
+                                  "relations should be in the given alphabet")
+                            rels[i][j][k]=alphabet.index(rels[i][j][k])
+            else:
+                for i in xrange(len(rels)):
+                    if not isinstance(rels[i],list):
+                        raise TypeError("each relation should "+
+                                        "be a pair of lists")
+                    if not len(rels[i]) == 2:
+                        raise ValueError("each relation should"+
+                                        " be a pair of lists")
+                    for j in [0,1]:
+                        if not isinstance(rels[i][j],list):
+                            raise TypeError("each word in relations should"+
+                                            " be represented by a list")
+                        for k in xrange(len(rels[i][j])):
+                            if not isinstance(rels[i][j][k],int):
+                                raise TypeError("elements referenced in"+
+                                  " relations should be in the given alphabet")
+                            if not rels[i][j][k] in alphabet:
+                                raise ValueError("elements referenced in"+
+                                " relations should be in the given alphabet")
+                            rels[i][j][k]=alphabet.index(rels[i][j][k])
+        else:
+            #Checks that not attempting to define relations on empty semigroup.
+            if not len(rels)==0: raise ValueError("empty semigroup can't have"+
+                                                    " any valid relations")
+            self._is_string_alphabet = True
+
+        #stores alphabet as a c string vector(even if input is integer vector)
+        self._alphabet = [str(i).encode('UTF-8')for i in alphabet]
+        self._relations = rels
+        self._extra = rels
+        self._congruence = new cpp.Congruence(self._cong,self._size,
+                                                self._relations,self._extra)
+
+    #TODO write == method for FpSemigroup
+    def size(self):
+        '''
+        Compute the size of an FpSemigroup (when finite).
+
+        Examples:
+            >>> FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"],
+                                                  ["ab","ba"]]).size()
+            5
+            >>> FpMonoid(["a","b"],[["aa","a"],["bbb","ab"],
+                                                  ["ab","ba"]]).size()
+            6
+            >>> FpMonoid(["a","b"],[["aa","a"],["bbb","ab"],
+                                                  ["ab","ba"]]).size()
+            6
+            >>> FpMonoid([1,2],[[[1,1],[1]],[[2,2,2,2,2],[2]],
+                                                  [[1,2],[2,1]]]).size()
+            10
+
+        Args:
+            None.
+
+        Returns:
+            int: The size of the FpSemigroup.
+
+        Raises:
+            None.
+        '''
+        return self._congruence.nr_classes()
+
+    def is_finite(self):
+        '''
+        attempts to check if a given FpSemigroup is finite(not always possible)
+
+        Examples:
+            >>> FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"],
+                                                  ["ab","ba"]]).is_finite()
+            True
+            >>> FpSemigroup(["a","b"],[]).is_finite()
+            False
+
+        Args:
+            None.
+
+        Returns:
+            bool: True for finite, False otherwise.
+
+        Raises:
+            None.
+        '''
+        if len(self._relations) < len(self._alphabet):return False
+        
+        for i in xrange(len(self._alphabet)):
+            check = False
+            for j in self._relations:
+                if i in list(j.first) or i in list(j.second):
+                    check=True
+            if not check:return False
+        self.size()
+        return True
+
+    def set_report(self, val):
+        '''
+        toggles wheather or not to report data when running certain functions
+
+        Examples:
+            None.
+
+        Args:
+            bool:toggle to True or False
+
+        Returns:
+            None.
+
+        Raises:
+            None.
+        '''
+        if not (val == True or val == False):
+            raise TypeError("set report input should be a boolean")
+        if val:
+            self._congruence.set_report(1)
+        else:
+            self._congruence.set_report(0)
+
+    def set_max_threads(self, nr_threads):
+        '''
+        sets the maximum number of threads to be used at once.
+
+        Examples:
+            None.
+
+        Args:
+            int:number of threads
+
+        Returns:
+            None.
+
+        Raises:
+            None.
+        '''
+        return self._congruence.set_max_threads(nr_threads)
+
+    def alphabet(self):
+        '''
+        returns the alphabet of the FpSemigroup.
+
+        Examples:
+            >>> FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"],
+                                                  ["ab","ba"]]).alphabet()
+            ['a', 'b']
+            >>> FpSemigroup([1,2],[[[1,1],[1]],[[2,1,2],[1,2]],
+                                               [[1,2],[2,1]]]).alphabet()
+            [1, 2]
+
+        Args:
+            None.
+
+        Returns:
+            list: the alphabet of the semigroup as a list.
+
+        Raises:
+            None.
+        '''
+        if self._is_string_alphabet:
+            return [str(i)[2:-1]for i in self._alphabet]
+        else:
+            return [int(i)for i in self._alphabet]
+
+    def is_confluent(self):
+        '''
+        check if the relations of the FpSemigroup are confulent.
+
+        Examples:
+            >>> FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"],
+                                                  ["ab","ba"]]).is_confluent()
+            True
+            >>> FpSemigroup(["a","b"],[["aa","a"],["bab","ab"],
+                                                  ["ab","ba"]]).is_confluent()
+            False
+
+        Args:
+            None.
+
+        Returns:
+            bool: True for confluent, False otherwise.
+
+        Raises:
+            None.
+        '''
+        self._rws = new cpp.RWS(self._relations)
+        return self._rws.is_confluent()
+
+    def word_to_class_index(self,word):
+        '''
+        returns the class index of a given word
+
+        Examples:
+        >>> FpS=FpSemigroup(["a","b"],[["aa","a"],["bab","ab"],["ab","ba"]])
+        >>> FpS.word_to_class_index(FpSemigroupElement(FpS,"a"))
+        0
+        >>> FpS.word_to_class_index(FpSemigroupElement(FpS,"b"))
+        1
+        >>> FpS=FpSemigroup([1,2],[[[1,1],[1]],[[2,1,2],[1,2]],[[1,2],[2,1]]])
+        >>> FpS.word_to_class_index(FpSemigroupElement(FpS,[1]))
+        0
+        >>> FpS.word_to_class_index(FpSemigroupElement(FpS,[2]))
+        1
+
+        Args:
+            FpSemigroupElement:word whose class index is to be returned.
+
+        Returns:
+            int: class index of the given word.
+
+        Raises:
+            TypeError: if 1st argument is not an FpSemigroupElement.
+            ValueError: if 1st argument is an FpSemigroupElement 
+            but not in this semigroup.
+        '''
+        if not isinstance(word,FpSemigroupElement):
+            raise TypeError("given word is not an FpSemigroupElement")
+
+        if isinstance(word,FpSemigroupElement):
+            if not word.semigroup() is self:
+                raise ValueError("given word is not in given semigroup")
+            word=word.word()
+
+        if isinstance(word,str):word=list(word)
+        
+        for i in xrange(len(word)):
+            word[i]=self.alphabet().index(word[i])
+
+        cdef vector[uint64_t] Word = word
+        return self._congruence.word_to_class_index(Word)
+
+
+    def __dealloc__(self):
+        '''
+        deletes c objects when semigroup is deleted
+
+        Examples:
+            None.
+
+        Args:
+            None.
+
+        Returns:
+            None.
+
+        Raises:
+            None.
+        '''
+        del self._congruence
+        del self._rws
+
+    def __repr__(self):
+        '''
+        displays the FpSemigroup via it's generators and relations
+        (or the number of them if ouput would be too long)
+
+        Examples:
+        >>> FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"],["ab","ba"]])
+        <Fpsemigroup <a,b|aa=a,bbb=ab,ab=ba>>
+        >>> FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[1,2]],[[1,2],[2,1]]])
+        <Fpsemigroup <1,2|11=1,222=12,12=21>>
+
+        Args:
+            None.
+
+        Returns:
+            str: <FpSemigroup with 'generators'|'relations'>>
+
+        Raises:
+            None.
+        '''
+        repalphabet = ','.join([str(j)[2:-1]for j in self._alphabet])
+        reprelations=','.join([''.join([str(self._alphabet[j])[2:-1]
+         for j in i.first]+["="]+[str(self._alphabet[j])[2:-1]
+         for j in i.second])for i in self._relations])
+        rep="<FpSemigroup <" + repalphabet + "|" + reprelations + ">>"
+        if len(rep)<80:
+            return rep
+        else:
+            return "<FpSemigroup with " + str(len(self._alphabet)) + \
+            " generators and " + str(len(self._relations)) + " relations>"
+
+cdef class FpMonoid(FpSemigroup):
+    """FpMonoid Object
+
+    Examples:
+    >>> FpMonoid(["a","b"],[["aa","a"],["bbb","ab"],["ab","ba"]])
+    <FpMonoid <a,b|aa=a,bbb=ab,ab=ba>>
+    >>> FpMonoid([1,2],[[[1,1],[1]],[[2,2,2],[1,2]],[[1,2],[2,1]]])
+    <FpMonoid <1,2|11=1,222=12,12=21>>
+
+    """    
+    cdef vector[pair[vector[uint64_t],vector[uint64_t]]] _e_relations
+
+    cdef vector[string] _e_alphabet
+
+    def __init__(self, alphabet, rels):
+        '''
+        Construct an FpMonoid from generators and relations.
+        
+        Args:
+            alphabet (list): the generators of the FpMonoid, must be 
+            either a list of ints or a list of strings of length 1.
+
+            rels (list): the relations containing pairs of words which are
+            equivalent in the given FpMonoid, must be a list of length 2 
+            lists of lists of ints or a list of length 2 lists of strings.
+
+        Returns:
+            None.
+
+        Raises:
+            TypeError: If the alphabet is not a list of integers or strings,
+            if the relations are not a double nested list of integers or a
+            nested list strings.
+
+            ValueError: If the alphabet contains repeated elements, if the 
+            alphabet uses the character 'e' or integer 0, if any of
+            the lists which are supposed to contain pairs of words don't 
+            contain 2 elements or any of the words in relations use generators
+            not in the given alphabet.
+        '''
+        if not isinstance(alphabet,list):
+            raise TypeError("alphabet should be a list")
+        self._size = len(alphabet)
+        self._cong = "twosided"
+        
+        # Checks if monoid is trivial.
+        if self._size > 0:
+            if not (isinstance(alphabet[0],int) or 
+            isinstance(alphabet[0],str)):
+                raise TypeError("alphabet should contain"+
+                    " characters or integers")
+            self._is_string_alphabet = isinstance(alphabet[0],str)
+
+            # Check that the alphabet does not contain duplicates.
+            for i in alphabet:
+                if not alphabet.count(i)==1:
+                    raise ValueError("alphabet should not"+
+                                    " have repeated elements")
+
+            if not isinstance(rels,list):
+                raise TypeError("relations should be stored n a list")
+            if self._is_string_alphabet:
+                if 'e' in alphabet: raise ValueError("alphabet can't"+
+                    " contain 'e' as this is reserved for the identity")
+                for i in xrange(len(rels)):
+                    if not isinstance(rels[i],list):
+                        raise TypeError("each relation should be" 
+                                        + " a pair of lists")
+                    if not len(rels[i]) == 2: 
+                        raise ValueError("each relation should"+
+                                        " be a pair of lists")
+                    for j in [0,1]:
+                        if not isinstance(rels[i][j],str):
+                            raise TypeError("if alphabet contains characters "
+                            + "then relations should be pairs of strings")
+                        rels[i][j] = list(rels[i][j])
+                        for k in xrange(len(rels[i][j])):
+                            if not rels[i][j][k] in alphabet:
+                                raise ValueError("elements referenced in "+
+                                "relations should be in the given alphabet")
+                            rels[i][j][k]=alphabet.index(rels[i][j][k])+1
+            else:
+                if 0 in alphabet:
+                    raise ValueError("alphabet can't contain 0 as this"+
+                                    " is reserved for the identity")
+                for i in xrange(len(rels)):
+                    if not isinstance(rels[i],list):
+                        raise TypeError("each relation should be"+
+                                        " a pair of lists")
+                    if not len(rels[i]) == 2:
+                        raise ValueError("each relation should be"+
+                                        " a pair of lists")
+                    for j in [0,1]:
+                        if not isinstance(rels[i][j],list):
+                            raise TypeError("each word in relations "+
+                                            "should be represented by a list")
+                        for k in xrange(len(rels[i][j])):
+                            if not isinstance(rels[i][j][k],int):
+                                raise TypeError("elements referenced in "+
+                                "relations should be in the given alphabet")
+                            if not rels[i][j][k] in alphabet:
+                                raise ValueError("elements referenced in "+
+                                "relations should be in the given alphabet")
+                            rels[i][j][k]=alphabet.index(rels[i][j][k])+1
+        else:
+            # Checks that not attempting to define relations on trivial monoid.
+            if not len(rels)==0:
+                raise ValueError("trivial monoid can't have any valid relations")
+            self._is_string_alphabet = True
+
+        #stores alphabet as a c string vector(even if input is integer vector)
+        self._alphabet = [str(i).encode('UTF-8')for i in alphabet]
+        self._relations = rels
+        self._extra = rels
+
+        if self._is_string_alphabet:
+            self._e_alphabet = [str(i).encode('UTF-8')for i in ['e']+alphabet]
+        else:
+            self._e_alphabet = [str(i).encode('UTF-8')for i in [0]+alphabet]
+
+        lefteq = [[[i+1,0],[i+1]]for i in xrange(self._size)]
+        righteq = [[[0,i+1],[i+1]]for i in xrange(self._size)]
+
+        self._e_relations = rels + [[[0,0],[0]]] + lefteq + righteq
+        self._congruence = new cpp.Congruence(self._cong,self._size + 1,
+                                                self._e_relations,self._extra)
+
+
+    def alphabet(self):
+        '''
+        returns the alphabet of the FpMonoid(including the identity which is represented as 0 or 'e').
+
+        Examples:
+            >>> FpMonoid(["a","b"],[["aa","a"],["bbb","ab"],["ab","ba"]]).alphabet()
+            ['e', 'a', 'b']
+            >>> FpMonoid([1,2],[[[1,1],[1]],[[2,1,2],[1,2]],[[1,2],[2,1]]]).alphabet()
+            [0, 1, 2]
+
+        Args:
+            None.
+
+        Returns:
+            list: the alphabet of the monoid as a list.
+
+        Raises:
+            None.
+        '''
+        if self._is_string_alphabet:
+            return [str(i)[2:-1]for i in self._e_alphabet]
+        else:
+            return [int(i)for i in self._e_alphabet]
+
+    def __repr__(self):
+        '''
+        displays the FpMonoid via it's generators and relations
+        (or the number of them if ouput would be too long)
+
+        Examples:
+            >>> FpMonoid(["a","b"],[["aa","a"],["bbb","ab"],["ab","ba"]])
+            <FpMonoid <a,b|aa=a,bbb=ab,ab=ba>>
+            >>> FpMonoid([1,2],[[[1,1],[1]],[[2,2,2],[1,2]],[[1,2],[2,1]]])
+            <FpMonoid <1,2|11=1,222=12,12=21>>
+
+        Args:
+            None.
+
+        Returns:
+            str: <FpMonoid with 'generators'|'relations'>>
+
+        Raises:
+            None.
+        '''
+        repalphabet = ','.join([str(j)[2:-1]for j in self._alphabet])
+        reprelations=','.join(
+                    [''.join([str(self._e_alphabet[j])[2:-1]for j in i.first]+
+                    ["="]+[str(self._e_alphabet[j])[2:-1]for j in i.second])
+                    for i in self._relations])
+
+        rep="<FpMonoid <" + repalphabet + "|" + reprelations + ">>"
+        if len(rep)<80:
+            return rep
+        else:
+            return "<FpMonoid with %s generators and %s relations>"%(
+                    `len(self._alphabet)`,`len(self._relations)`)
+
+cdef class FpSemigroupElement(Element):
+    """FpSemigroupElement Object
+
+    Examples:
+    >>> FpS=FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"],["ab","ba"]])
+    >>> FpSemigroupElement(FpS,"a")
+    <FpSemigroup Element 'a'>
+    >>> FpSemigroupElement(FpS,"bab")
+    <FpSemigroup Element 'bab'>
+    >>> FpS=FpSemigroup([1,2],[[[1,1],[1]],[[2,1,2],[1,2]],[[1,2],[2,1]]])
+    >>> FpSemigroupElement(FpS,[1])
+    <FpSemigroup Element '[1]'>
+    >>> FpSemigroupElement(FpS,[2,1,2])
+    <FpSemigroup Element '[2, 1, 2]'>
+
+
+    """ 
+    cdef FpSemigroup _FpS
+    cdef string _Word
+
+    def __init__(self,FpS,word):
+        '''
+        Construct an FpSemigroup element from an FpSemigroup and a string.
+        
+        Args:
+            FpS (FpSemigroup): The FpSemigroup of which the given word is 
+            an element.
+            word (list/string): a string or a list containg generators of
+            the given semigroup.
+
+        Returns:
+            None.
+
+        Raises:
+            TypeError: If 1st argument is not an FpSemigroup object or the
+            second argument is not a string or a list.
+            ValueError: If the word contains a generator not n the alphabet
+            of the given semigroup.
+        '''       
+        if not isinstance(FpS,FpSemigroup):
+            raise TypeError("given Semigroup is not a valid FpSemigroup") 
+        if not (isinstance(word,str) or isinstance(word,list)):
+            raise TypeError("given word must be a string or list of integers")
+        self._FpS = FpS
+
+        for i in word:
+                if not i in FpS.alphabet():
+                    raise ValueError("given word is not in the given FpMonoid")
+
+        if self._FpS._is_string_alphabet:
+            if word =="":
+                raise ValueError("empty word not well defined")
+            else:
+                self._Word = word.encode('UTF-8')
+        else:
+            if word =="":
+                raise ValueError("empty word not well defined")
+            else:
+                self._Word = str(word).encode('UTF-8')
+
+    def semigroup(self):
+        '''
+        retrurns the semigroup of which this element is a member.
+
+        Examples:
+            >>> FpS=FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"]
+                                                     ,["ab","ba"]])
+            >>> FpSemigroupElement(FpS,"bab").semigroup()
+            <FpSemigroup <a,b|aa=a,bbb=ab,ab=ba>>
+            >>> FpS=FpSemigroup([1,2],[[[1,1],[1]],[[2,1,2],[1,2]]
+                                                  ,[[1,2],[2,1]]])
+            >>> FpSemigroupElement(FpS,[1]).semigroup()
+            <FpSemigroup <1,2|11=1,212=12,12=21>>
+
+        Args:
+            None.
+
+        Returns:
+            FpSemigroup:semigroup of which this element is a member
+
+        Raises:
+            None.
+        '''
+        return self._FpS
+
+    def word(self):
+        '''
+        retrurns the word representing the element as a string or list.
+
+        Examples:
+            >>> FpS=FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"]
+                                                     ,["ab","ba"]])
+            >>> FpSemigroupElement(FpS,"ab").word()
+            'ab'
+            >>> FpS=FpSemigroup([1,2],[[[1,1],[1]],[[2,1,2],[1,2]]
+                                                  ,[[1,2],[2,1]]])
+            >>> FpSemigroupElement(FpS,[1]).word()
+            [1]
+
+        Args:
+            None.
+
+        Returns:
+            string/list:word representing the element as a string or list.
+
+        Raises:
+            None.
+        '''
+        if self._FpS._is_string_alphabet:
+            return str(self._Word)[2:-1]
+        else:
+            return eval(self._Word)
+        
+
+    def __mul__(self, other):
+        '''
+        multiplies 2 FpSemigroup elements(self on left, other on right).
+
+        Examples:
+            >>> FpS=FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"]
+                                                     ,["ab","ba"]])
+            >>> FpSemigroupElement(FpS,"a")*FpSemigroupElement(FpS,"a")
+            0
+            >>> FpSemigroupElement(FpS,"a")*FpSemigroupElement(FpS,"ab")
+            1
+            >>> FpS=FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[2]]
+                                                  ,[[1,2],[2,1]]])
+            >>> FpSemigroupElement(FpS,[1])*FpSemigroupElement(FpS,[1])
+            0
+            >>> FpSemigroupElement(FpS,[1])*FpSemigroupElement(FpS,[1,2])
+            1
+
+        Args:
+            other (FpSemigroupElement):element to be multiplied by on the right
+
+        Returns:
+            int:class index of the solution to the multiplication
+
+        Raises:
+            None.
+        '''
+        if not (isinstance(other,FpSemigroupElement) and 
+                self.semigroup() is other.semigroup()):
+            raise TypeError("given words are not members"+
+                            " of the same FpSemigroup")
+        if isinstance(self.semigroup(),FpMonoid):
+            return self.semigroup().word_to_class_index(FpMonoidElement(
+                            self.semigroup(),self.word() + other.word()))
+        else:
+            return self.semigroup().word_to_class_index(FpSemigroupElement(
+                            self.semigroup(),self.word() + other.word()))
+
+    def __repr__(self):
+        '''
+        displays the FpSemigroup element
+
+        Examples:
+            >>> FpS=FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"]
+                                                     ,["ab","ba"]])
+            >>> FpSemigroupElement(FpS,"a")
+            <FpSemigroup Element 'a'>
+            >>> FpSemigroupElement(FpS,"ab")
+            <FpSemigroup Element 'ab'>
+            >>> FpS=FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[2]]
+                                                  ,[[1,2],[2,1]]])
+            >>> FpSemigroupElement(FpS,[1])
+            <FpSemigroup Element '[1]'>
+            >>> FpSemigroupElement(FpS,[1,2])
+            <FpSemigroup Element '[1, 2]'>
+
+        Args:
+            None.
+
+        Returns:
+            str: "<FpSemigroup Element 'word'>"
+
+        Raises:
+            None.
+        '''
+        return "<FpSemigroup Element " + str(self._Word)[1:] + ">"
+
+    def __dealloc__(self):
+        '''
+        deletes c objects when FpSemigroup element is deleted
+
+        Examples:
+            None.
+
+        Args:
+            None.
+
+        Returns:
+            None.
+
+        Raises:
+            None.
+        '''
+        del self._handle
+
+cdef class FpMonoidElement(FpSemigroupElement):
+    """FpMonoidElement Object
+
+    Examples:
+    >>> FpM=FpMonoid(["a","b"],[["aa","a"],["bbb","ab"],["ab","ba"]])
+    >>> FpMonoidElement(FpM,"a")
+    <FpMonoid Element 'a'>
+    >>> FpMonoidElement(FpM,"bab")
+    <FpMonoid Element 'bab'>
+    >>> FpM=FpMonoid([1,2],[[[1,1],[1]],[[2,1,2],[1,2]],[[1,2],[2,1]]])
+    >>> FpMonoidElement(FpM,[1])
+    <FpMonoid Element '[1]'>
+    >>> FpMonoidElement(FpM,[2,1,2])
+    <FpMonoid Element '[2, 1, 2]'>
+    """ 
+
+
+    def __init__(self,FpM,word):
+        '''
+        Construct an fpMonoid element from an FpMonoid and a word.
+        
+        Args:
+            FpM (FpMonoid): The FpMonoid of which the given word is an element.
+            word (list/string): a string or a list containg generators of the
+            given semigroup.
+
+        Returns:
+            None.
+
+        Raises:
+            TypeError: If 1st argument is not an FpMonoid object or the second
+            argument is not a string or a list.
+            ValueError: If the word contains a generator not n the alphabet of
+            the given monoid.
+        '''       
+        if not isinstance(FpM,FpMonoid):
+            raise TypeError("given monoid is not a valid FpMonoid") 
+        if not (isinstance(word,str) or isinstance(word,list)):
+            raise TypeError("given word must be a string or list of integers")
+        self._FpS = FpM
+
+        for i in word:
+            if not i in FpM.alphabet():
+                raise ValueError("given word is not in the given FpMonoid")
+
+        if self._FpS._is_string_alphabet:
+            if word =="":
+                self._Word ="e".encode('UTF-8')
+            else:
+                self._Word = word.encode('UTF-8')
+        else:
+            if word =="":
+                self._Word ="0".encode('UTF-8')
+            else:
+                self._Word = str(word).encode('UTF-8')
+
+
+    def monoid(self):
+        '''
+        retrurns the monoid of which this element is a member.
+
+        Examples:
+            >>> FpM=FpMonoid(["a","b"],[["aa","a"],["bbb","ab"],["ab","ba"]])
+            >>> FpMonoidElement(FpM,"bab").monoid()
+            <FpMonoid <a,b|aa=a,bbb=ab,ab=ba>>
+            >>> FpM=FpMonoid([1,2],[[[1,1],[1]],[[2,1,2],[1,2]],[[1,2],[2,1]]])
+            >>> FpMonoidElement(FpM,[1]).monoid()
+            <FpMonoid <1,2|11=1,212=12,12=21>>
+
+        Args:
+            None.
+
+        Returns:
+            FpMonoid:monoid of which this element is a member
+
+        Raises:
+            None.
+        '''
+        return self._FpS
+
+    def __repr__(self):
+        '''
+        displays the FpMonoid element
+
+        Examples:
+            >>> FpM=FpMonoid(["a","b"],[["aa","a"],["bbb","ab"],["ab","ba"]])
+            >>> FpMonoidElement(FpM,"a")
+            <FpMonoid Element 'a'>
+            >>> FpMonoidElement(FpM,"ab")
+            <FpMonoid Element 'ab'>
+            >>> FpM=FpMonoid([1,2],[[[1,1],[1]],[[2,2,2],[2]],[[1,2],[2,1]]])
+            >>> FpMonoidElement(FpM,[1])
+            <FpMonoid Element '[1]'>
+            >>> FpMonoidElement(FpM,[1,2])
+            <FpMonoid Element '[1, 2]'>
+
+        Args:
+            None.
+
+        Returns:
+            str: "<FpSemigroup Element 'word'>"
+
+        Raises:
+            None.
+        '''
+        return "<FpMonoid Element " + str(self._Word)[1:] + ">"
 

--- a/python-bindings/semigroups.pyx
+++ b/python-bindings/semigroups.pyx
@@ -417,7 +417,7 @@ def FullTransformationMonoid(n):
                       Transformation([0, 0] + list(range(2, n))), 
                       Transformation([n - 1] + list(range(n - 1)))])
 
-cdef class FpSemigroup:
+cdef class FpSemigroup(Semigroup):
     """FpSemigroup Object
 
     Examples:
@@ -429,6 +429,7 @@ cdef class FpSemigroup:
     Todo:
          write == method  
          write normal_form method
+         test compatability with existing semigroup member functions
          add link to documentation for functions when it becomes available.
     """    
 
@@ -874,10 +875,10 @@ cdef class FpMonoid(FpSemigroup):
                             + "then relations should be pairs of strings")
                         rels[i][j] = list(rels[i][j])
                         for k in xrange(len(rels[i][j])):
-                            if not rels[i][j][k] in alphabet:
+                            if not rels[i][j][k] in ['e']+alphabet:
                                 raise ValueError("elements referenced in "+
                                 "relations should be in the given alphabet")
-                            rels[i][j][k]=alphabet.index(rels[i][j][k])+1
+                            rels[i][j][k]=(['e']+alphabet).index(rels[i][j][k])
             else:
                 if 0 in alphabet:
                     raise ValueError("alphabet can't contain 0 as this"+
@@ -897,10 +898,10 @@ cdef class FpMonoid(FpSemigroup):
                             if not isinstance(rels[i][j][k],int):
                                 raise TypeError("elements referenced in "+
                                 "relations should be in the given alphabet")
-                            if not rels[i][j][k] in alphabet:
+                            if not rels[i][j][k] in [0]+alphabet:
                                 raise ValueError("elements referenced in "+
                                 "relations should be in the given alphabet")
-                            rels[i][j][k]=alphabet.index(rels[i][j][k])+1
+                            rels[i][j][k]=([0]+alphabet).index(rels[i][j][k])
         else:
             # Checks that not attempting to define relations on trivial monoid.
             if not len(rels)==0:

--- a/python-bindings/semigroups_cpp.pxd
+++ b/python-bindings/semigroups_cpp.pxd
@@ -7,10 +7,11 @@
 
 from libc.stdint cimport uint16_t
 from libc.stdint cimport uint32_t
+from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libcpp cimport bool
-from libcpp cimport string
+from libcpp.string cimport string
 
 cdef extern from "<libsemigroups/semigroups.h>" namespace "libsemigroups":
     cdef cppclass Element:
@@ -49,12 +50,22 @@ cdef extern from "<libsemigroups/semigroups.h>" namespace "libsemigroups":
         bool test_membership(Element* x)
         vector[size_t]* factorisation(size_t pos)
         void enumerate(size_t limit)
+
+cdef extern from "libsemigroups/cong.h" namespace "libsemigroups":
     cdef cppclass Congruence:
-        Congruence(string, 
-                   int, 
-                   vector[pair[vector[int], vector[int]]],
-                   vector[pair[vector[int], vector[int]]])
+        Congruence(string, size_t, vector[pair[vector[uint64_t],vector[uint64_t]]],
+                        vector[pair[vector[uint64_t],vector[uint64_t]]]) except +
         int nr_classes()
+        int word_to_class_index(vector[uint64_t] word)
+        void set_report(bool val)
+        void set_max_threads(size_t nr_threads)
+        
+
+cdef extern from "libsemigroups/rws.h" namespace "libsemigroups":
+    cdef cppclass RWS:
+        RWS(vector[pair[vector[uint64_t],vector[uint64_t]]]) except +
+        bool is_confluent()
+      
 
 cdef extern from "semigroups_cpp.h" namespace "libsemigroups":
     cdef cppclass PythonElement(Element):

--- a/python-bindings/tests/FpSemigroup.test.py
+++ b/python-bindings/tests/FpSemigroup.test.py
@@ -23,11 +23,31 @@ class TestFpSemigroup(unittest.TestCase):
         FpSemigroup(["a"], [["a", "aa"]])
         FpSemigroup(["a","b"], [["b", "aa"]])
 
-    def test_alphabet(self):
+    def test_alphabet_str(self):
+        with self.assertRaises(ValueError):
+            FpSemigroup([], [["a", "aa"]])
+        with self.assertRaises(ValueError):
+            FpSemigroup(["a"], [["b", "aa"]])
+        with self.assertRaises(ValueError):
+            FpSemigroup(["a","a"], [["b", "aa"]])
+
+    def test_alphabet_int(self):
         with self.assertRaises(ValueError):
             FpSemigroup([], [[[1], [0, 0]]])
         with self.assertRaises(TypeError):
             FpSemigroup(1, [[[1], [0, 0]]])
+
+    def test_rels_str(self):
+        with self.assertRaises(TypeError):
+            FpSemigroup(["a","b"], "['a', 'aa']")
+        with self.assertRaises(TypeError):
+            FpSemigroup(["a","b"], ["'b', 'aa'"])
+        with self.assertRaises(ValueError):
+            FpSemigroup(["a","b"], [['a', 'aa', 'b']])
+        with self.assertRaises(TypeError):
+            FpSemigroup(["a","b"], [['b', ['a','a']]])
+        with self.assertRaises(ValueError):
+            FpSemigroup(["a","b"], [['b', 'ca']])
 
     def test_rels_int(self):
         with self.assertRaises(TypeError):
@@ -43,52 +63,57 @@ class TestFpSemigroup(unittest.TestCase):
         with self.assertRaises(ValueError):
             FpSemigroup([0,1], [[[1], [2, 0]]])
 
-    def test_alphabet_str(self):
-        with self.assertRaises(ValueError):
-            FpSemigroup([], [["a", "aa"]])
-        with self.assertRaises(ValueError):
-            FpSemigroup(["a"], [["b", "aa"]])
-        with self.assertRaises(ValueError):
-            FpSemigroup(["a","a"], [["b", "aa"]])
+    def test_set_report_str(self):
+        S=FpSemigroup(["a"], [["a", "aa"]])
+        S.set_report(True)
+        S.set_report(False)
+        with self.assertRaises(TypeError):
+            S.set_report('False')
 
-    def test_rels_str(self):
-        with self.assertRaises(TypeError):
-            FpSemigroup(["a","b"], "['a', 'aa']")
-        with self.assertRaises(TypeError):
-            FpSemigroup(["a","b"], ["'b', 'aa'"])
-        with self.assertRaises(ValueError):
-            FpSemigroup(["a","b"], [['a', 'aa', 'b']])
-        with self.assertRaises(TypeError):
-            FpSemigroup(["a","b"], [['b', ['a','a']]])
-        with self.assertRaises(ValueError):
-            FpSemigroup(["a","b"], [['b', 'ca']])
-
-    def test_set_report(self):
+    def test_set_report_int(self):
         S=FpSemigroup([0], [[[0], [0, 0]]])
         S.set_report(True)
         S.set_report(False)
         with self.assertRaises(TypeError):
             S.set_report('False')
 
-    def test_size(self):
+    def test_size_str(self):
         self.assertEqual(FpSemigroup(["a"], [["a", "aa"]]).size(),1)
         self.assertEqual(FpSemigroup(["a","b"], [["a", "aa"],['b','bb'],\
         ['ab','ba']]).size(),3)
+
+    def test_size_int(self):
         self.assertEqual(FpSemigroup([0], [[[0], [0,0]]]).size(),1)
         self.assertEqual(FpSemigroup([0,1], [[[0], [0,0]],[[1],[1,1]],\
         [[0,1],[1,0]]]).size(),3)
 
-    def test_word_to_class_index(self):
+    def test_word_to_class_index_str(self):
         FpS=FpSemigroup(["a","b"], [["a", "aa"],['b','bb'],['ab','ba']])
         FpS2=FpSemigroup([],[])
         e=FpSemigroupElement(FpS,"aba")
         FpS.word_to_class_index(e)
         with self.assertRaises(TypeError):
-            FpS.word_to_class_index(1)
+            FpS.word_to_class_index("a")
+        with self.assertRaises(TypeError):
             FpS.word_to_class_index([1,'0'])
+        with self.assertRaises(ValueError):
             FpS.word_to_class_index(FpSemigroupElement(FpS2,"aba"))
         self.assertEqual(FpS.word_to_class_index(e),
         FpS.word_to_class_index(FpSemigroupElement(FpS,"abaaabb")))
+
+    def test_word_to_class_index_int(self):
+        FpS=FpSemigroup([1,2], [[[1], [1,1]],[[2],[2,2]],[[1,2],[2,1]]])
+        FpS2=FpSemigroup([],[])
+        e=FpSemigroupElement(FpS,[1,2,1])
+        FpS.word_to_class_index(e)
+        with self.assertRaises(TypeError):
+            FpS.word_to_class_index(1)
+        with self.assertRaises(TypeError):
+            FpS.word_to_class_index([1,'0'])
+        with self.assertRaises(ValueError):
+            FpS.word_to_class_index(FpSemigroupElement(FpS2,[1,2,1]))
+        self.assertEqual(FpS.word_to_class_index(e),
+        FpS.word_to_class_index(FpSemigroupElement(FpS,[1,2,1,1,2,1])))
 
     def test_repr(self):
         self.assertEqual(FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[2]],\
@@ -102,7 +127,7 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","b"],["ab","ba"]]).__repr__(),\
 
 class TestFpSemigroupElement(unittest.TestCase):
 
-    def test_valid_init(self):
+    def test_valid_init_str(self):
         FpS=FpSemigroup(["a","b"],[["aa","a"],["bbb","b"],["ba","ab"]])
         FpSemigroupElement(FpS,"aba")
         FpSemigroupElement(FpS,"a")
@@ -120,7 +145,20 @@ class TestFpSemigroupElement(unittest.TestCase):
         with self.assertRaises(ValueError):
             FpSemigroupElement(FpS,"abc")
 
-    def test_mul(self):
+    def test_valid_init_int(self):
+        FpS=FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[2]],[[2,1],[1,2]]])
+        FpSemigroupElement(FpS,[1,2,1])
+        FpSemigroupElement(FpS,[1])
+        with self.assertRaises(ValueError):
+            FpSemigroupElement(FpS,"")
+        with self.assertRaises(TypeError):
+            FpSemigroupElement([1,2,1],[1,2,1])
+        with self.assertRaises(TypeError):
+            FpSemigroupElement(FpS,FpS)
+        with self.assertRaises(ValueError):
+            FpSemigroupElement(FpS,[1,2,3])
+
+    def test_mul_str(self):
         FpS=FpSemigroup(["a","b"],[["aa","a"],["bbb","b"],["ba","ab"]])
         other = "aa"
         a=FpSemigroupElement(FpS,"aba")
@@ -132,6 +170,18 @@ class TestFpSemigroupElement(unittest.TestCase):
         self.assertEqual(a*a,FpS.word_to_class_index( \
                         FpSemigroupElement(FpS,"abaaba")))
 
+    def test_mul_int(self):
+        FpS=FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[2]],[[2,1],[1,2]]])
+        other = [1,1]
+        a=FpSemigroupElement(FpS,[1,2,1])
+        a*a
+        with self.assertRaises(TypeError):
+            a*other
+        with self.assertRaises(TypeError):
+            FpSemigroupElement(FpSemigroup([1,2],[]),[1,2,1])*a
+        self.assertEqual(a*a,FpS.word_to_class_index( \
+                        FpSemigroupElement(FpS,[1,2,1,1,2,1])))
+
     def test_repr(self):
         FpS = FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[2]]])
         self.assertEqual(FpSemigroupElement(FpS,[1,2]).__repr__(),
@@ -140,6 +190,42 @@ class TestFpSemigroupElement(unittest.TestCase):
         self.assertEqual(FpSemigroupElement(FpS,"ab").__repr__(),
                                         "<FpSemigroup Element 'ab'>")
 
+    def test_word_to_class_index_str(self):
+        A=FpSemigroupElement(FpSemigroup(["a","b"],[["aa","a"],["bbb","b"],
+                                    ["ab","ba"]]),"a")
+        self.assertEqual(A.word_to_class_index(),0)
+        B=FpSemigroupElement(A.semigroup(),"b")
+        self.assertEqual(B.word_to_class_index(),1)
+        AB=FpSemigroupElement(A.semigroup(),"ab")
+        self.assertEqual(AB.word_to_class_index(),2)
+
+
+        E=FpMonoidElement(FpMonoid(["a","b"],[["aa","a"],["bbb","b"],
+                                    ["ab","ba"]]),"")
+        self.assertEqual(E.word_to_class_index(),0)
+        A=FpMonoidElement(E.monoid(),"a")
+        self.assertEqual(A.word_to_class_index(),1)
+        B=FpMonoidElement(E.monoid(),"b")
+        self.assertEqual(B.word_to_class_index(),2)
+
+
+    def test_word_to_class_index_int(self):
+        A=FpSemigroupElement(FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[2]],
+                                    [[1,2],[2,1]]]),[1])
+        self.assertEqual(A.word_to_class_index(),0)
+        B=FpSemigroupElement(A.semigroup(),[2])
+        self.assertEqual(B.word_to_class_index(),1)
+        AB=FpSemigroupElement(A.semigroup(),[1,2])
+        self.assertEqual(AB.word_to_class_index(),2)
+
+
+        E=FpMonoidElement(FpMonoid([1,2],[[[1,1],[1]],[[2,2,2],[2]],
+                                    [[1,2],[2,1]]]),[])
+        self.assertEqual(E.word_to_class_index(),0)
+        A=FpMonoidElement(E.monoid(),[1])
+        self.assertEqual(A.word_to_class_index(),1)
+        B=FpMonoidElement(E.monoid(),[2])
+        self.assertEqual(B.word_to_class_index(),2)
 
 class TestFpMonoid(unittest.TestCase):
 
@@ -155,11 +241,31 @@ class TestFpMonoid(unittest.TestCase):
         FpMonoid(["a","b"], [["b", "aa"]])
         FpMonoid(["a","b"], [["e", "aa"]])
 
-    def test_alphabet(self):
+    def test_alphabet_str(self):
+        with self.assertRaises(ValueError):
+            FpMonoid([], [["a", "aa"]])
+        with self.assertRaises(ValueError):
+            FpMonoid(["a"], [["b", "aa"]])
+        with self.assertRaises(ValueError):
+            FpMonoid(["a","a"], [["b", "aa"]])
+
+    def test_alphabet_int(self):
         with self.assertRaises(ValueError):
             FpMonoid([], [[[1], [2, 2]]])
         with self.assertRaises(TypeError):
             FpMonoid(1, [[[1], [2, 2]]])
+
+    def test_rels_str(self):
+        with self.assertRaises(TypeError):
+            FpMonoid(["a","b"], "['a', 'aa']")
+        with self.assertRaises(TypeError):
+            FpMonoid(["a","b"], ["'b', 'aa'"])
+        with self.assertRaises(ValueError):
+            FpMonoid(["a","b"], [['a', 'aa', 'b']])
+        with self.assertRaises(TypeError):
+            FpMonoid(["a","b"], [['b', ['a','a']]])
+        with self.assertRaises(ValueError):
+            FpMonoid(["a","b"], [['b', 'ca']])
 
     def test_rels_int(self):
         with self.assertRaises(TypeError):
@@ -175,27 +281,14 @@ class TestFpMonoid(unittest.TestCase):
         with self.assertRaises(ValueError):
             FpMonoid([1,2], [[[1], [3, 2]]])
 
-    def test_alphabet_str(self):
-        with self.assertRaises(ValueError):
-            FpMonoid([], [["a", "aa"]])
-        with self.assertRaises(ValueError):
-            FpMonoid(["a"], [["b", "aa"]])
-        with self.assertRaises(ValueError):
-            FpMonoid(["a","a"], [["b", "aa"]])
+    def test_set_report_str(self):
+        M=FpMonoid(["a"], [["a", "aa"]])
+        M.set_report(True)
+        M.set_report(False)
+        with self.assertRaises(TypeError):
+            M.set_report('False')
 
-    def test_rels_str(self):
-        with self.assertRaises(TypeError):
-            FpMonoid(["a","b"], "['a', 'aa']")
-        with self.assertRaises(TypeError):
-            FpMonoid(["a","b"], ["'b', 'aa'"])
-        with self.assertRaises(ValueError):
-            FpMonoid(["a","b"], [['a', 'aa', 'b']])
-        with self.assertRaises(TypeError):
-            FpMonoid(["a","b"], [['b', ['a','a']]])
-        with self.assertRaises(ValueError):
-            FpMonoid(["a","b"], [['b', 'ca']])
-
-    def test_set_report(self):
+    def test_set_report_int(self):
         M=FpMonoid([1], [[[1], [1, 1]]])
         M.set_report(True)
         M.set_report(False)
@@ -210,20 +303,26 @@ class TestFpMonoid(unittest.TestCase):
         self.assertEqual(FpMonoid([1,2], [[[2], [2,2]],[[1],[1,1]],
         [[2,1],[1,2]]]).size(),4)
 
-    def test_word_to_class_index(self):
+    def test_word_to_class_index_str(self):
         FpM=FpMonoid(["a","b"], [["a", "aa"],['b','bb'],['ab','ba']])
+        self.assertEqual(FpMonoidElement(FpM,"").word_to_class_index(),0)
         FpM2=FpMonoid([],[])
-        FpM.word_to_class_index(FpSemigroupElement(FpM,"aba"))
+        FpMonoidElement(FpM,"aba").word_to_class_index()
         a=FpMonoidElement(FpM,"aba")
-        FpM.word_to_class_index(a)
-        with self.assertRaises(TypeError):
-            FpM.word_to_class_index(1)
-        with self.assertRaises(TypeError):
-            FpM.word_to_class_index([2,'1'])
-        with self.assertRaises(ValueError):
-            FpM.word_to_class_index(FpSemigroupElement(FpM2,"aba"))
-        self.assertEqual(FpM.word_to_class_index(a),
-        FpM.word_to_class_index(FpMonoidElement(FpM,"abaaabb")))
+        a.word_to_class_index()
+        self.assertEqual(a*a,
+        FpMonoidElement(FpM,"abaaabb").word_to_class_index())
+
+    def test_word_to_class_index_int(self):
+        FpM=FpMonoid([1,2], [[[1], [1,1]],[[2],[2,2]],[[1,2],[2,1]]])
+        self.assertEqual(FpMonoidElement(FpM,[]).word_to_class_index(),0)
+        FpM2=FpMonoid([],[])
+        FpMonoidElement(FpM,[1,2,1]).word_to_class_index()
+        a=FpMonoidElement(FpM,[1,2,1])
+        a.word_to_class_index()
+        self.assertEqual(a*a,
+        FpMonoidElement(FpM,[1,2,1,1,2,1]).word_to_class_index())
+
 
     def test_repr(self):
         self.assertEqual(FpMonoid([1,2],[[[1,1],[1]],[[2,2,2],[2]],\
@@ -249,6 +348,22 @@ class TestFpMonoidElement(unittest.TestCase):
             FpMonoidElement(FpM,FpM)
         with self.assertRaises(ValueError):
             FpMonoidElement(FpM,"abc")
+        with self.assertRaises(ValueError):
+            FpMonoidElement(FpM,[])
+
+    def test_valid_init_int(self):
+        FpM=FpMonoid([1,2],[[[1,1],[1]],[[2,2,2],[2]],[[2,1],[1,2]]])
+        FpMonoidElement(FpM,[1,2,1])
+        FpMonoidElement(FpM,[1])
+        FpMonoidElement(FpM,[])
+        with self.assertRaises(TypeError):
+            FpMonoidElement([1,2,1],[1,2,1])
+        with self.assertRaises(TypeError):
+            FpMonoidElement(FpM,FpM)
+        with self.assertRaises(ValueError):
+            FpMonoidElement(FpM,[1,2,3])
+        with self.assertRaises(ValueError):
+            FpMonoidElement(FpM,"")
 
     def test_mul(self):
         FpM=FpMonoid(["a","b"],[["aa","a"],["bbb","b"],["ba","ab"]])
@@ -260,8 +375,24 @@ class TestFpMonoidElement(unittest.TestCase):
             a*other
         with self.assertRaises(TypeError):
             FpMonoidElement(FpMonoid(["a","b"],[]),"aba")*a
-        self.assertEqual(a*a,FpM.word_to_class_index(FpMonoidElement(FpM,"abaaba")))
+
+        self.assertEqual(a*a,
+         FpM.word_to_class_index(FpMonoidElement(FpM,"abaaba")))
         self.assertEqual(a*e,FpM.word_to_class_index(a))
+
+    def test_mul_int(self):
+        FpM=FpMonoid([1,2],[[[1,1],[1]],[[2,2,2],[2]],[[2,1],[1,2]]])
+        other = [1,1]
+        a=FpMonoidElement(FpM,[1,2,1])
+        a*a
+        e=FpMonoidElement(FpM,[])
+        with self.assertRaises(TypeError):
+            a*other
+        with self.assertRaises(TypeError):
+            FpMonoidElement(FpMonoid([1,2],[]),[1,2,1])*a
+        self.assertEqual(a*a,
+            FpMonoidElement(FpM,[1,2,1,1,2,1]).word_to_class_index())
+        self.assertEqual(a*e,a.word_to_class_index())
 
 if __name__ == '__main__':
     unittest.main()

--- a/python-bindings/tests/FpSemigroup.test.py
+++ b/python-bindings/tests/FpSemigroup.test.py
@@ -147,11 +147,13 @@ class TestFpMonoid(unittest.TestCase):
         FpMonoid([1,2], [])
         FpMonoid([1,2], [[[1], [1, 1]]])
         FpMonoid([1,2,3], [[[2], [1, 1]]])
+        FpMonoid([1,2,3], [[[0], [1, 1]]])
 
         FpMonoid([], [])
         FpMonoid(["a"], [])
         FpMonoid(["a"], [["a", "aa"]])
         FpMonoid(["a","b"], [["b", "aa"]])
+        FpMonoid(["a","b"], [["e", "aa"]])
 
     def test_alphabet(self):
         with self.assertRaises(ValueError):

--- a/python-bindings/tests/FpSemigroup.test.py
+++ b/python-bindings/tests/FpSemigroup.test.py
@@ -1,0 +1,265 @@
+import unittest
+import sys
+import os
+
+path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if not path in sys.path:
+    sys.path.insert(1, path)
+del path
+
+from semigroups import FpSemigroup
+from semigroups import FpSemigroupElement
+from semigroups import FpMonoid
+from semigroups import FpMonoidElement
+
+class TestFpSemigroup(unittest.TestCase):
+
+    def test_valid_init(self):
+        FpSemigroup([0,1], [])
+        FpSemigroup([0,1], [[[0], [0, 0]]])
+        FpSemigroup([0,1,2], [[[1], [0, 0]]])
+
+        FpSemigroup(["a"], [])
+        FpSemigroup(["a"], [["a", "aa"]])
+        FpSemigroup(["a","b"], [["b", "aa"]])
+
+    def test_alphabet(self):
+        with self.assertRaises(ValueError):
+            FpSemigroup([], [[[1], [0, 0]]])
+        with self.assertRaises(TypeError):
+            FpSemigroup(1, [[[1], [0, 0]]])
+
+    def test_rels_int(self):
+        with self.assertRaises(TypeError):
+            FpSemigroup([0,1], "[[1], [0, 0]]")
+        with self.assertRaises(TypeError):
+            FpSemigroup([0,1], ["[1], [0, 0]"])
+        with self.assertRaises(ValueError):
+            FpSemigroup([0,1], [[[1], [0, 0], [1]]])
+        with self.assertRaises(TypeError):
+            FpSemigroup([0,1], [[[1], "0, 0"]])
+        with self.assertRaises(TypeError):
+            FpSemigroup([0,1], [[["1"], [0, 0]]])
+        with self.assertRaises(ValueError):
+            FpSemigroup([0,1], [[[1], [2, 0]]])
+
+    def test_alphabet_str(self):
+        with self.assertRaises(ValueError):
+            FpSemigroup([], [["a", "aa"]])
+        with self.assertRaises(ValueError):
+            FpSemigroup(["a"], [["b", "aa"]])
+        with self.assertRaises(ValueError):
+            FpSemigroup(["a","a"], [["b", "aa"]])
+
+    def test_rels_str(self):
+        with self.assertRaises(TypeError):
+            FpSemigroup(["a","b"], "['a', 'aa']")
+        with self.assertRaises(TypeError):
+            FpSemigroup(["a","b"], ["'b', 'aa'"])
+        with self.assertRaises(ValueError):
+            FpSemigroup(["a","b"], [['a', 'aa', 'b']])
+        with self.assertRaises(TypeError):
+            FpSemigroup(["a","b"], [['b', ['a','a']]])
+        with self.assertRaises(ValueError):
+            FpSemigroup(["a","b"], [['b', 'ca']])
+
+    def test_set_report(self):
+        S=FpSemigroup([0], [[[0], [0, 0]]])
+        S.set_report(True)
+        S.set_report(False)
+        with self.assertRaises(TypeError):
+            S.set_report('False')
+
+    def test_size(self):
+        self.assertEqual(FpSemigroup(["a"], [["a", "aa"]]).size(),1)
+        self.assertEqual(FpSemigroup(["a","b"], [["a", "aa"],['b','bb'],\
+        ['ab','ba']]).size(),3)
+        self.assertEqual(FpSemigroup([0], [[[0], [0,0]]]).size(),1)
+        self.assertEqual(FpSemigroup([0,1], [[[0], [0,0]],[[1],[1,1]],\
+        [[0,1],[1,0]]]).size(),3)
+
+    def test_word_to_class_index(self):
+        FpS=FpSemigroup(["a","b"], [["a", "aa"],['b','bb'],['ab','ba']])
+        FpS2=FpSemigroup([],[])
+        e=FpSemigroupElement(FpS,"aba")
+        FpS.word_to_class_index(e)
+        with self.assertRaises(TypeError):
+            FpS.word_to_class_index(1)
+            FpS.word_to_class_index([1,'0'])
+            FpS.word_to_class_index(FpSemigroupElement(FpS2,"aba"))
+        self.assertEqual(FpS.word_to_class_index(e),
+        FpS.word_to_class_index(FpSemigroupElement(FpS,"abaaabb")))
+
+    def test_repr(self):
+        self.assertEqual(FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[2]],\
+        [[1,2],[2,1]]]).__repr__(),"<FpSemigroup <1,2|11=1,222=2,12=21>>")
+        self.assertEqual(FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"],\
+        ["ab","ba"]]).__repr__(),"<FpSemigroup <a,b|aa=a,bbb=ab,ab=ba>>")
+        self.assertEqual(FpSemigroup(["a","b"],[["aa","a"],["bbbbbbbbbbbbbb\
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","b"],["ab","ba"]]).__repr__(),\
+        "<FpSemigroup with 2 generators and 3 relations>")
+
+
+class TestFpSemigroupElement(unittest.TestCase):
+
+    def test_valid_init(self):
+        FpS=FpSemigroup(["a","b"],[["aa","a"],["bbb","b"],["ba","ab"]])
+        FpSemigroupElement(FpS,"aba")
+        FpSemigroupElement(FpS,"a")
+        FpS=FpSemigroup(["m","o"],[["ooo","o"]])
+        FpSemigroupElement(FpS,"moo")
+        FpSemigroupElement(FpS,"ooo")
+        FpS=FpSemigroup(list("cowie"),[])
+        FpSemigroupElement(FpS,"cowie")
+        with self.assertRaises(ValueError):
+            FpSemigroupElement(FpS,"")
+        with self.assertRaises(TypeError):
+            FpSemigroupElement("aba","aba")
+        with self.assertRaises(TypeError):
+            FpSemigroupElement(FpS,FpS)
+        with self.assertRaises(ValueError):
+            FpSemigroupElement(FpS,"abc")
+
+    def test_mul(self):
+        FpS=FpSemigroup(["a","b"],[["aa","a"],["bbb","b"],["ba","ab"]])
+        other = "aa"
+        a=FpSemigroupElement(FpS,"aba")
+        a*a
+        with self.assertRaises(TypeError):
+            a*other
+        with self.assertRaises(TypeError):
+            FpSemigroupElement(FpSemigroup(["a","b"],[]),"aba")*a
+        self.assertEqual(a*a,FpS.word_to_class_index( \
+                        FpSemigroupElement(FpS,"abaaba")))
+
+    def test_repr(self):
+        FpS = FpSemigroup([1,2],[[[1,1],[1]],[[2,2,2],[2]]])
+        self.assertEqual(FpSemigroupElement(FpS,[1,2]).__repr__(),
+                                        "<FpSemigroup Element '[1, 2]'>")
+        FpS = FpSemigroup(["a","b"],[["aa","a"],["bbb","b"],["ab","ba"]])
+        self.assertEqual(FpSemigroupElement(FpS,"ab").__repr__(),
+                                        "<FpSemigroup Element 'ab'>")
+
+
+class TestFpMonoid(unittest.TestCase):
+
+    def test_valid_init(self):
+        FpMonoid([1,2], [])
+        FpMonoid([1,2], [[[1], [1, 1]]])
+        FpMonoid([1,2,3], [[[2], [1, 1]]])
+
+        FpMonoid([], [])
+        FpMonoid(["a"], [])
+        FpMonoid(["a"], [["a", "aa"]])
+        FpMonoid(["a","b"], [["b", "aa"]])
+
+    def test_alphabet(self):
+        with self.assertRaises(ValueError):
+            FpMonoid([], [[[1], [2, 2]]])
+        with self.assertRaises(TypeError):
+            FpMonoid(1, [[[1], [2, 2]]])
+
+    def test_rels_int(self):
+        with self.assertRaises(TypeError):
+            FpMonoid([1,2], "[[1], [2, 2]]")
+        with self.assertRaises(TypeError):
+            FpMonoid([1,2], ["[1], [2, 2]"])
+        with self.assertRaises(ValueError):
+            FpMonoid([1,2], [[[1], [2, 2], [1]]])
+        with self.assertRaises(TypeError):
+            FpMonoid([1,2], [[[1], "2, 2"]])
+        with self.assertRaises(TypeError):
+            FpMonoid([1,2], [[["1"], [2, 2]]])
+        with self.assertRaises(ValueError):
+            FpMonoid([1,2], [[[1], [3, 2]]])
+
+    def test_alphabet_str(self):
+        with self.assertRaises(ValueError):
+            FpMonoid([], [["a", "aa"]])
+        with self.assertRaises(ValueError):
+            FpMonoid(["a"], [["b", "aa"]])
+        with self.assertRaises(ValueError):
+            FpMonoid(["a","a"], [["b", "aa"]])
+
+    def test_rels_str(self):
+        with self.assertRaises(TypeError):
+            FpMonoid(["a","b"], "['a', 'aa']")
+        with self.assertRaises(TypeError):
+            FpMonoid(["a","b"], ["'b', 'aa'"])
+        with self.assertRaises(ValueError):
+            FpMonoid(["a","b"], [['a', 'aa', 'b']])
+        with self.assertRaises(TypeError):
+            FpMonoid(["a","b"], [['b', ['a','a']]])
+        with self.assertRaises(ValueError):
+            FpMonoid(["a","b"], [['b', 'ca']])
+
+    def test_set_report(self):
+        M=FpMonoid([1], [[[1], [1, 1]]])
+        M.set_report(True)
+        M.set_report(False)
+        with self.assertRaises(TypeError):
+            M.set_report('False')
+
+    def test_size(self):
+        self.assertEqual(FpMonoid(["a"], [["a", "aa"]]).size(),2)
+        self.assertEqual(FpMonoid(["a","b"], [["a", "aa"],['b','bb'],
+        ['ab','ba']]).size(),4)
+        self.assertEqual(FpMonoid([1], [[[1], [1,1]]]).size(),2)
+        self.assertEqual(FpMonoid([1,2], [[[2], [2,2]],[[1],[1,1]],
+        [[2,1],[1,2]]]).size(),4)
+
+    def test_word_to_class_index(self):
+        FpM=FpMonoid(["a","b"], [["a", "aa"],['b','bb'],['ab','ba']])
+        FpM2=FpMonoid([],[])
+        FpM.word_to_class_index(FpSemigroupElement(FpM,"aba"))
+        a=FpMonoidElement(FpM,"aba")
+        FpM.word_to_class_index(a)
+        with self.assertRaises(TypeError):
+            FpM.word_to_class_index(1)
+        with self.assertRaises(TypeError):
+            FpM.word_to_class_index([2,'1'])
+        with self.assertRaises(ValueError):
+            FpM.word_to_class_index(FpSemigroupElement(FpM2,"aba"))
+        self.assertEqual(FpM.word_to_class_index(a),
+        FpM.word_to_class_index(FpMonoidElement(FpM,"abaaabb")))
+
+    def test_repr(self):
+        self.assertEqual(FpMonoid([1,2],[[[1,1],[1]],[[2,2,2],[2]],\
+        [[1,2],[2,1]]]).__repr__(),"<FpMonoid <1,2|11=1,222=2,12=21>>")
+        self.assertEqual(FpMonoid(["a","b"],[["aa","a"],["bbb","ab"],\
+        ["ab","ba"]]).__repr__(),"<FpMonoid <a,b|aa=a,bbb=ab,ab=ba>>")
+        self.assertEqual(FpMonoid(["a","b"],[["aa","a"],["bbbbbbbbbbbbbb\
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","b"],["ab","ba"]]).__repr__(),\
+        "<FpMonoid with 2 generators and 3 relations>")
+
+class TestFpMonoidElement(unittest.TestCase):
+
+    def test_valid_init(self):
+        FpM=FpMonoid(["a","b"],[["aa","a"],["bbb","b"],["ba","ab"]])
+        FpMonoidElement(FpM,"aba")
+        FpMonoidElement(FpM,"a")
+        FpM=FpMonoid(["m","o"],[["ooo","o"]])
+        FpMonoidElement(FpM,"moo")
+        FpMonoidElement(FpM,"")
+        with self.assertRaises(TypeError):
+            FpMonoidElement("aba","aba")
+        with self.assertRaises(TypeError):
+            FpMonoidElement(FpM,FpM)
+        with self.assertRaises(ValueError):
+            FpMonoidElement(FpM,"abc")
+
+    def test_mul(self):
+        FpM=FpMonoid(["a","b"],[["aa","a"],["bbb","b"],["ba","ab"]])
+        other = "aa"
+        a=FpMonoidElement(FpM,"aba")
+        a*a
+        e=FpMonoidElement(FpM,"")
+        with self.assertRaises(TypeError):
+            a*other
+        with self.assertRaises(TypeError):
+            FpMonoidElement(FpMonoid(["a","b"],[]),"aba")*a
+        self.assertEqual(a*a,FpM.word_to_class_index(FpMonoidElement(FpM,"abaaba")))
+        self.assertEqual(a*e,FpM.word_to_class_index(a))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Introduces `FpSemigroup`, `FpMonoid` and `FpSemigroupElement` and `FpMonoidElement` classes as well as unittests and documentation for all of these.

Note that there is currently no normal form function for words so multiplication is currently done by returning the word to class index of the product.

The following member functions are included:

### FpSemigroup
* `init`
* `size`
* `is_finite`
* `set_report`
* `set_max_threads`
* `alphabet`
* `is_confluent`
* `word_to_class_index`
* `dealloc`
* `repr`

### FpMonoid
* `init`
* `alphabet`
* `repr`

### FpSemigroupElement
* `init`
* `semigroup`
* `word`
* `mul`
* `repr`
* `dealloc`
* `word_to_class_index`

### FpMonoid
* `init`
* `monoid`
* `repr`
