### PR TITLE
test_less_than should delete all non-winning DATA objects

### DIFF
--- a/src/cong.cc
+++ b/src/cong.cc
@@ -101,6 +101,7 @@ namespace libsemigroups {
         REPORT("allocation failed: " << e.what())
         return;
       }
+      _kill_mtx.lock();  // stop two DATA objects from killing each other
       if (!data.at(pos)->is_killed()) {
         for (auto it = data.begin(); it < data.begin() + pos; it++) {
           (*it)->kill();
@@ -109,6 +110,7 @@ namespace libsemigroups {
           (*it)->kill();
         }
       }
+      _kill_mtx.unlock();
     };
 
     size_t nr_threads;
@@ -296,9 +298,9 @@ namespace libsemigroups {
 
   void Congruence::init_relations(Semigroup*         semigroup,
                                   std::atomic<bool>& killed) {
-    _mtx.lock();
+    _init_mtx.lock();
     if (_relations_done || semigroup == nullptr) {
-      _mtx.unlock();
+      _init_mtx.unlock();
       _relations_done = true;
       return;
     }
@@ -332,7 +334,7 @@ namespace libsemigroups {
       }
       _relations_done = true;
     }
-    _mtx.unlock();
+    _init_mtx.unlock();
   }
 
   // This is the default method used by a DATA object, and is used only by TC

--- a/src/cong.cc
+++ b/src/cong.cc
@@ -328,7 +328,8 @@ namespace libsemigroups {
       // If this is an fp semigroup congruence, then KBP is the only DATA
       // subtype which can return a sensible answer.  Forcing KBP is not an
       // ideal solution; perhaps fp semigroup congruences should be handled
-      // differently in future.
+      // differently in future.  In particular, we should use _data if it
+      // happens to be a KBP object already.
       data = new KBP(*this);
       data->run();
       Partition<word_t>* out = data->nontrivial_classes();

--- a/src/cong.h
+++ b/src/cong.h
@@ -616,6 +616,8 @@ namespace libsemigroups {
                        bool                       ignore_max_threads = false,
                        std::function<bool(DATA*)> goal_func = RETURN_FALSE);
 
+    bool is_obviously_infinite();
+
     Congruence(cong_t                         type,
                size_t                         nrgens,
                std::vector<relation_t> const& relations,

--- a/src/cong.h
+++ b/src/cong.h
@@ -629,6 +629,8 @@ namespace libsemigroups {
 
     DATA*                   _data;
     std::vector<relation_t> _extra;
+    std::mutex              _init_mtx;
+    std::mutex              _kill_mtx;
     size_t                  _max_threads;
     size_t                  _nrgens;
     std::vector<DATA*>      _partial_data;
@@ -637,7 +639,6 @@ namespace libsemigroups {
     std::atomic<bool>       _relations_done;
     Semigroup*              _semigroup;
     cong_t                  _type;
-    std::mutex              _mtx;
 
     static size_t const INFTY;
     static size_t const UNDEFINED;

--- a/src/cong.h
+++ b/src/cong.h
@@ -213,6 +213,19 @@ namespace libsemigroups {
         };
         data = get_data(words_func);
       }
+
+      if (!_partial_data.empty()) {
+        assert(_data == nullptr);
+        // Delete the losers and clear _partial_data
+        for (size_t i = 0; i < _partial_data.size(); i++) {
+          if (_partial_data[i] != data) {
+            delete _partial_data[i];
+          }
+        }
+        _partial_data.clear();
+      }
+      _data = data;
+
       DATA::result_t result = data->current_less_than(w1, w2);
       assert(result != DATA::result_t::UNKNOWN);
       return result == DATA::result_t::TRUE;

--- a/src/cong/tc.cc
+++ b/src/cong/tc.cc
@@ -89,6 +89,7 @@ namespace libsemigroups {
         _extra(),
         _forwd(1, UNDEFINED),
         _id_coset(0),
+        _init_done(false),
         _last(0),
         _next(UNDEFINED),
         _pack(120000),
@@ -100,19 +101,15 @@ namespace libsemigroups {
         _tc_done(false) {}
 
   void Congruence::TC::init() {
-    if (_relations.empty() && _extra.empty()) {
+    if (!_init_done) {
       // This is the first run
       init_tc_relations();
       // Apply each "extra" relation to the first coset only
       for (relation_t const& rel : _extra) {
         trace(_id_coset, rel);  // Allow new cosets
       }
-      if (_relations.empty() && !_killed) {
-        _tc_done = true;
-        compress();
-        return;
-      }
     }
+    _init_done = true;
   }
 
   void Congruence::TC::prefill() {
@@ -182,7 +179,7 @@ namespace libsemigroups {
 
   void Congruence::TC::init_tc_relations() {
     // This should not have been run before
-    assert(_relations.empty() && _extra.empty());
+    assert(!_init_done);
 
     // Handle _extra first!
     switch (_cong._type) {

--- a/src/cong/tc.h
+++ b/src/cong/tc.h
@@ -80,7 +80,8 @@ namespace libsemigroups {
     size_t                            _defined;
     std::vector<relation_t>           _extra;
     std::vector<class_index_t>        _forwd;
-    class_index_t                     _id_coset;  // TODO(JDM) Remove?
+    class_index_t                     _id_coset;   // TODO(JDM) Remove?
+    bool                              _init_done;  // Has init() been run yet?
     class_index_t                     _last;
     std::stack<class_index_t> _lhs_stack;  // Stack for identifying cosets
     class_index_t             _next;

--- a/test/cong.test.cc
+++ b/test/cong.test.cc
@@ -838,3 +838,17 @@ TEST_CASE("Congruence 24: example from GAP which once messed up prefill",
 
   REQUIRE(cong.nr_classes() == 1);
 }
+
+TEST_CASE("Congruence 25: free semigroup with redundant relations",
+          "[standard][congruence][multithread][fpsemigroup]") {
+  std::vector<relation_t> extra = {relation_t({0, 0}, {0, 0})};
+  Congruence              cong("twosided", 1, {}, extra);
+  REQUIRE(cong.test_equals({0, 0}, {0, 0}));
+}
+
+TEST_CASE("Congruence 26: free semigroup with redundant relations",
+          "[standard][congruence][multithread][fpsemigroup]") {
+  Congruence cong("twosided", 1, {}, {});
+  REQUIRE(cong.test_equals({0, 0}, {0, 0}));
+  REQUIRE(!cong.test_equals({0, 0}, {0}));
+}


### PR DESCRIPTION
There are various changes here, but the important one is "cong: in test_less_than, delete all but the winning DATA".  This ensures that if sorting is ever done, it is done consistently from that time on.  It's possible we'll want to change this later on to always use Knuth-Bendix, or something like that - but for now this makes things consistent.

We've also got a handful of other changes, which should make sure certain bugs never arise.  Each "fix" is in its own commit.