### PR TITLE
Add default constructor to IteratorMethods and IteratorMethodsPairFirst

### DIFF
--- a/src/semigroups.h
+++ b/src/semigroups.h
@@ -998,6 +998,7 @@ namespace libsemigroups {
     };  // iterator_base definition ends
 
     struct IteratorMethods {
+      IteratorMethods() {}
       typename std::vector<Element const*>::const_reference indirection(
           typename std::vector<Element const*>::const_iterator it) const {
         return *it;
@@ -1009,6 +1010,7 @@ namespace libsemigroups {
     };
 
     struct IteratorMethodsPairFirst {
+      IteratorMethodsPairFirst() {}
       typename std::vector<Element const*>::const_reference indirection(
           typename std::vector<std::pair<Element const*, element_index_t>>::
               const_iterator it) const {


### PR DESCRIPTION
This small change is required to resolve [issue 380 on the Semigroups package](https://github.com/gap-packages/Semigroups/issues/380). My (old) compiler was complaining that these default constructors were missing.