### PR TITLE
travis: remove explicit GAPDoc download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
     - GAP_FORK=gap-system
     - GAP_BRANCH=master
     - IOVERS=4.5.0
-    - GAPDOCVERS=1.6
     - ORBVERS=4.8.0
     - GENSSVERS=1.6.4
     - SEMIGROUPS_BR=master

--- a/ci/travis-gap.sh
+++ b/ci/travis-gap.sh
@@ -42,13 +42,6 @@ cd digraphs
 make
 cd ..
 
-# GAPDoc
-GAPDOC=GAPDoc-$GAPDOCVERS
-echo "Downloading $GAPDOC..."
-curl -L -O https://www.gap-system.org/pub/gap/gap4/tar.gz/packages/$GAPDOC.tar.gz
-tar xzf $GAPDOC.tar.gz
-rm $GAPDOC.tar.gz
-
 # GenSS
 GENSS=genss-$GENSSVERS
 echo "Downloading $GENSS..."


### PR DESCRIPTION
It's included in `packages-required-master.tar.gz`, which we install
anyway.