### PR TITLE
Fix intermittent test failure in GAP package Semigroups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,15 @@ matrix:
             - gcc-5
             - g++-5
     - env: TEST_SUITE=quick # Test with gcc-4
-    # - env: TEST_SUITE=gap GAP_FORK=gap-system GAP_BRANCH=master IOVERS=4.5.0 ORBVERS=4.8.0 GENSSVERS=1.6.4 SEMIGROUPS_BR=master DIGRAPHS_BR=master
-    - env: TEST_SUITE=gap MATRIX_EVAL="CC=gcc-5 && CXX=g++-5" GAP_FORK=gap-system GAP_BRANCH=master IOVERS=4.5.0 ORBVERS=4.8.0 GENSSVERS=1.6.4 SEMIGROUPS_BR=master DIGRAPHS_BR=master
+      # - env: TEST_SUITE=gap MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" GAP_FORK=gap-system GAP_BRANCH=master IOVERS=4.5.1 ORBVERS=4.8.0 GENSSVERS=1.6.4 SEMIGROUPS_BR=master DIGRAPHS_BR=master
+      # addons:
+      #   apt:
+      #     sources:
+      #       - ubuntu-toolchain-r-test
+      #     packages:
+      #       - gcc-4.9
+      #       - g++-4.9
+    - env: TEST_SUITE=gap MATRIX_EVAL="CC=gcc-5 && CXX=g++-5" GAP_FORK=gap-system GAP_BRANCH=master IOVERS=4.5.1 ORBVERS=4.8.0 GENSSVERS=1.6.4 SEMIGROUPS_BR=master DIGRAPHS_BR=master
       addons:
         apt:
           sources:

--- a/src/cong/kbfp.cc
+++ b/src/cong/kbfp.cc
@@ -39,10 +39,11 @@ namespace libsemigroups {
   void Congruence::KBFP::init() {
     if (_semigroup != nullptr) {
       return;
+    } else if (_rws->nr_rules() == 0) {
+      _cong.init_relations(_cong._semigroup, _killed);
+      _rws->add_rules(_cong.relations());
+      _rws->add_rules(_cong.extra());
     }
-    _cong.init_relations(_cong._semigroup, _killed);
-    _rws->add_rules(_cong.relations());
-    _rws->add_rules(_cong.extra());
 
     LIBSEMIGROUPS_ASSERT(_cong._semigroup == nullptr || !_cong.extra().empty());
 

--- a/src/cong/tc.h
+++ b/src/cong/tc.h
@@ -72,7 +72,6 @@ namespace libsemigroups {
     inline void trace(class_index_t const&, relation_t const&, bool add = true);
 
     size_t                            _active;  // Number of active cosets
-    bool                              _already_reported_killed;
     std::vector<signed_class_index_t> _bckwd;
     size_t                            _cosets_killed;
     class_index_t                     _current;

--- a/src/rws.cc
+++ b/src/rws.cc
@@ -420,8 +420,8 @@ namespace libsemigroups {
   // CONFLUENT from Sims, p62
   bool RWS::confluent(std::atomic<bool>& killed) const {
     // FIXME if the stack is not empty then what happens here?
-    LIBSEMIGROUPS_ASSERT(_stack.empty());
-    if (!_confluence_known) {
+    if (!_confluence_known && !killed) {
+      LIBSEMIGROUPS_ASSERT(_stack.empty());
       _confluent        = true;
       _confluence_known = true;
       rws_word_t word1;

--- a/tests/recvec.test.cc
+++ b/tests/recvec.test.cc
@@ -1286,7 +1286,7 @@ TEST_CASE("RecVec 35: iterator assignment constructor", "[quick][recvec][35]") {
   }
 
   for (size_t i = 0; i < 99; i++) {
-    auto it = rv.begin_row(i);
+    auto it  = rv.begin_row(i);
     auto it2 = rv.begin_row(i + 1);
 
     it++;


### PR DESCRIPTION
This PR fixes numerous incorrect asserts in the `Congruence` class and prevents the class `Congruence::TC` from being in an invalid state if it is killed. The last issue is probably the source of the intermittent test failure observed in 

https://github.com/gap-packages/Semigroups/issues/450