### PR TITLE
travis: limit builds to non-feature branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ dist: trusty
 sudo: required
 compiler:
   - gcc
+branches:
+  only:
+  - master
+  - stable-/\d+\.\d+/
+  - /^v\d+\.\d+\.\d+$/
 matrix:
   include:
     - env: TEST_SUITE=lint


### PR DESCRIPTION
I.e. to `stable-X.Y`, `master`, and releases `vX.Y.Z`.