### PR TITLE
provide pkg-config data and install it (backport of PR 106)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ gh-pages
 config.status
 config.log
 *~
-Makefile.in
 README
 aclocal.m4
 autom4te.cache/
@@ -26,6 +25,8 @@ configure
 *.la
 libtool
 *.in
+!libsemigroups.pc.in
+libsemigroups.pc
 autom4te.cache
 config
 .!*

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,9 @@ BENCHMARK_LINT_FORMAT += benchmark/src/semigroups.bm.cpp
 BENCHMARK_LINT_FORMAT += benchmark/src/nridempotents.bm.cpp
 BENCHMARK_LINT_FORMAT += benchmark/src/examples.h
 
+pkgconfigdir       = $(libdir)/pkgconfig
+pkgconfig_DATA     = libsemigroups.pc
+
 ## lstest sources 
 
 CHECK_LOG_DIR = tests/log

--- a/configure.ac
+++ b/configure.ac
@@ -78,5 +78,5 @@ AX_CODE_COVERAGE()
 
 dnl Output configured files
 
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile libsemigroups.pc])
 AC_OUTPUT

--- a/libsemigroups.pc.in
+++ b/libsemigroups.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@prefix@/include
+
+Name: @PACKAGE_NAME@
+Description: C++ library for semigroups and monoids
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lsemigroups
+Cflags: -I${includedir}


### PR DESCRIPTION
with this,

./autogen.sh && ./configure --prefix=foo && make install

provide, on a (virtual) system with pkg-config knowing about "foo" goodies such as

$ pkg-config --modversion libsemigroups
0.6.4

(if "--prefix=" is omitted then, with sudo blessing, "make install" will land
/usr/local/lib/pkgconfig/libsemigroups.pc)

Also, autoconfing of libsemigroups as a dependency will be simplified
by calling PKG_CHECK_MODULES()