### PR TITLE
Add radix_sort and count_sort functions

### DIFF
--- a/include/libsemigroups/freeband.hpp
+++ b/include/libsemigroups/freeband.hpp
@@ -26,7 +26,7 @@
 
 #include "libsemigroups/constants.hpp"
 #include "libsemigroups/libsemigroups-debug.hpp"
-#include "types.hpp" // word_type
+#include "types.hpp"  // word_type
 
 namespace libsemigroups {
 
@@ -41,50 +41,48 @@ namespace libsemigroups {
 
   void standardize(word_type& x);
 
-    template <typename T>
-    word_type right(T const first, T const last, size_t const k) {
-      // LIBSEMIGROUPS_ASSERT(is_standardized(first, last));
-      word_type out;
-      if (std::distance(first, last) == 0) {
-        return out;
-      }
-      T                   j            = first;
-      size_t              content_size = 0;
-      size_t const        N = *std::max_element(first, last) + 1;
-      std::vector<size_t> multiplicity(N + 1, 0);
-      for (auto i = first; i != last; ++i) {
-        if (i != first) {
-          LIBSEMIGROUPS_ASSERT(multiplicity[*(i- 1)] != 0);
-          --multiplicity[*(i - 1)];
-          if (multiplicity[*(i - 1)] == 0) {
-            --content_size;
-          }
-        }
-        while (j < last
-              && (multiplicity[*j] != 0 || content_size < k)) {
-          if (multiplicity[*j] == 0) {
-            ++content_size;
-          }
-          ++multiplicity[*j];
-          ++j;
-        }
-        out.push_back(content_size == k ? size_t(std::distance(first, j)) - 1
-                                        : UNDEFINED);
-      }
+  template <typename T>
+  word_type right(T const first, T const last, size_t const k) {
+    // LIBSEMIGROUPS_ASSERT(is_standardized(first, last));
+    word_type out;
+    if (std::distance(first, last) == 0) {
       return out;
     }
-
-    // Reverses and corrects output of "right" to "left"
-    word_type reverse(word_type&& out) {
-      std::reverse(out.begin(), out.end());
-      for (auto& x : out) {
-        if (x != UNDEFINED) {
-          x = out.size() - x - 1;
+    T                   j            = first;
+    size_t              content_size = 0;
+    size_t const        N            = *std::max_element(first, last) + 1;
+    std::vector<size_t> multiplicity(N + 1, 0);
+    for (auto i = first; i != last; ++i) {
+      if (i != first) {
+        LIBSEMIGROUPS_ASSERT(multiplicity[*(i - 1)] != 0);
+        --multiplicity[*(i - 1)];
+        if (multiplicity[*(i - 1)] == 0) {
+          --content_size;
         }
       }
-      return std::move(out);
+      while (j < last && (multiplicity[*j] != 0 || content_size < k)) {
+        if (multiplicity[*j] == 0) {
+          ++content_size;
+        }
+        ++multiplicity[*j];
+        ++j;
+      }
+      out.push_back(content_size == k ? size_t(std::distance(first, j)) - 1
+                                      : UNDEFINED);
     }
+    return out;
+  }
 
+  // Reverses and corrects output of "right" to "left"
+  word_type reverse(word_type&& out) {
+    std::reverse(out.begin(), out.end());
+    for (auto& x : out) {
+      if (x != UNDEFINED) {
+        x = out.size() - x - 1;
+      }
+    }
+    return std::move(out);
+  }
 
 }  // namespace libsemigroups
 

--- a/include/libsemigroups/freeband.hpp
+++ b/include/libsemigroups/freeband.hpp
@@ -84,6 +84,66 @@ namespace libsemigroups {
     return std::move(out);
   }
 
+  // What types should we be using? I get that word_type is an alias to
+  // std::vector<size_t>, but wouldnt using the vector be more useful,
+  // since the output/input is not really a representation of a word.
+  // Also the input i here will range from 0 to 3, so is it better
+  // to assign it to a unsigned short or something?
+  word_type count_sort(std::vector<word_type> const& level_edges,
+                       word_type const&              index_list,
+                       size_t                        i,
+                       size_t                        radix) {
+    // Could actually reuse an already existing count array
+    word_type counts(radix + 1, 0);
+    for (auto j : index_list) {
+      if (level_edges[j][i] != UNDEFINED)
+        counts[level_edges[j][i]]++;
+      else
+        counts[radix]++;
+    }
+    for (size_t j = 1; j < counts.size(); j++)
+      counts[j] += counts[j - 1];
+    // This can also be reused and doesnt even have to be initialized if we
+    // reuse it.
+    word_type result_index_list(index_list.size(), 0);
+    for (auto j = index_list.rbegin(); j != index_list.rend(); j++) {
+      if (level_edges[*j][i] != UNDEFINED) {
+        counts[level_edges[*j][i]]--;
+        result_index_list[counts[level_edges[*j][i]]] = *j;
+      } else {
+        counts[radix]--;
+        result_index_list[counts[radix]] = *j;
+      }
+    }
+    // Could also swap result_index_list with index_list!
+    return result_index_list;
+  }
+
+  word_type radix_sort(std::vector<word_type> const& level_edges,
+                       size_t                        alphabet_size) {
+    // Can reuse this instead of initializing every time
+    word_type index_list(level_edges.size(), 0);
+    for (size_t j = 0; j < index_list.size(); j++)
+      index_list[j] = j;
+
+    index_list = count_sort(level_edges, index_list, 0, index_list.size());
+    index_list = count_sort(level_edges, index_list, 1, alphabet_size);
+    index_list = count_sort(level_edges, index_list, 2, alphabet_size);
+    index_list = count_sort(level_edges, index_list, 3, index_list.size());
+
+    // Reuse
+    word_type result_index_list(index_list.size(), 0);
+    size_t    c = 0;
+    for (size_t j = 1; j < index_list.size(); j++) {
+      if (level_edges[index_list[j]] != level_edges[index_list[j - 1]])
+        c++;
+      result_index_list[index_list[j]] = c;
+    }
+    result_index_list[index_list[0]] = 0;
+    // Something something, swap instead
+    return result_index_list;
+  }
+
 }  // namespace libsemigroups
 
 #endif

--- a/tests/test-freeband.cpp
+++ b/tests/test-freeband.cpp
@@ -50,4 +50,60 @@ namespace libsemigroups {
         == word_type(
             {4, 4, 5, 7, 8, 9, UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED}));
   }
+
+  LIBSEMIGROUPS_TEST_CASE("Test radix_sort", "002", "", "[freeband][quick]") {
+    std::vector<word_type> level_edges = {{0, 0, 0, 0},
+                                          {0, 1, 1, 0},
+                                          {0, 2, 2, 0},
+                                          {0, 0, 0, 0},
+                                          {0, 1, 1, 0},
+                                          {0, 2, 2, 0}};
+    REQUIRE(radix_sort(level_edges, 3) == word_type({0, 1, 2, 0, 1, 2}));
+    level_edges = std::vector<word_type>(
+        6, word_type({UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED}));
+    REQUIRE(radix_sort(level_edges, 3) == word_type({0, 0, 0, 0, 0, 0}));
+    level_edges = {{0, 0, 0, 1},
+                   {UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED},
+                   {0, 0, 0, 1},
+                   {0, 0, 0, 1},
+                   {UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED},
+                   {0, 0, 0, 1}};
+    REQUIRE(radix_sort(level_edges, 8) == word_type({0, 1, 0, 0, 1, 0}));
+    level_edges = {{1, 2, 0, 5},
+                   {1, 2, 0, 5},
+                   {1, 2, 0, 5},
+                   {5, 3, 3, 5},
+                   {8, 3, 3, 5},
+                   {5, 3, 3, 5},
+                   {8, 3, 3, 5},
+                   {7, 2, 3, 5},
+                   {10, 2, 3, 5},
+                   {5, 0, 0, 4},
+                   {8, 0, 0, 4},
+                   {2, 2, 0, 4},
+                   {1, 2, 0, 4},
+                   {4, 3, 1, 9},
+                   {UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED},
+                   {UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED},
+                   {UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED},
+                   {UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED},
+                   {UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED},
+                   {UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED},
+                   {1, 1, 0, 4},
+                   {1, 1, 0, 5},
+                   {1, 1, 0, 4},
+                   {1, 1, 0, 5},
+                   {5, 1, 2, 6},
+                   {5, 1, 2, 7},
+                   {5, 1, 3, 4},
+                   {5, 1, 3, 5},
+                   {5, 1, 2, 3},
+                   {5, 1, 2, 2},
+                   {5, 1, 0, 4},
+                   {4, 3, 1, 9}};
+    REQUIRE(radix_sort(level_edges, 4)
+            == word_type({10, 10, 10, 14, 15, 14, 15, 12, 13, 2, 3,
+                          7,  6,  18, 19, 19, 19, 19, 19, 19, 4, 9,
+                          4,  9,  16, 17, 8,  11, 1,  0,  5,  18}));
+  }
 }  // namespace libsemigroups

--- a/tests/test-freeband.cpp
+++ b/tests/test-freeband.cpp
@@ -19,8 +19,8 @@
 #include "catch.hpp"      // for REQUIRE etc
 #include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 
-#include "libsemigroups/freeband.hpp"
 #include "libsemigroups/constants.hpp"
+#include "libsemigroups/freeband.hpp"
 
 namespace libsemigroups {
 


### PR DESCRIPTION
This PR adds the radix_sort function for the sorting step of the equality testing algorithm. The current implementation can be improved by reusing memory better.