### PR TITLE
Update Aho-corasick

### DIFF
--- a/include/libsemigroups/aho-corasick.hpp
+++ b/include/libsemigroups/aho-corasick.hpp
@@ -115,7 +115,7 @@ namespace libsemigroups {
     }
 
     // TODO to cpp
-    // Add links_exist flag
+    // TODO Add flags to show links have been cleared?
     void add_word_no_checks(const_iterator first, const_iterator last) {
       clear_suffix_links();
       index_type current = root;
@@ -242,7 +242,7 @@ namespace libsemigroups {
     // in this vector
     void rm_node(index_type i) {
       LIBSEMIGROUPS_ASSERT(i < _nodes.size());
-      // _nodes.erase(_nodes.begin() + i);
+      _nodes.erase(_nodes.begin() + i);
     }
   };
 

--- a/include/libsemigroups/aho-corasick.hpp
+++ b/include/libsemigroups/aho-corasick.hpp
@@ -115,6 +115,7 @@ namespace libsemigroups {
     }
 
     // TODO to cpp
+    // Add links_exist flag
     void add_word_no_checks(const_iterator first, const_iterator last) {
       clear_suffix_links();
       index_type current = root;
@@ -165,11 +166,16 @@ namespace libsemigroups {
       add_word_no_checks(w.cbegin(), w.cend());
     }
 
+    void rm_word_no_checks(word_type const& w) {
+      rm_word_no_checks(w.cbegin(), w.cend());
+    }
+
     // TODO to cpp
     [[nodiscard]] index_type traverse(const_iterator first,
                                       const_iterator last) const {
       index_type current = root;
       for (auto it = first; it != last; ++it) {
+        // Uses private traverse by node function
         current = traverse(current, *it);
       }
       return current;
@@ -232,9 +238,11 @@ namespace libsemigroups {
       }
     }
 
+    // This breaks traversal, as node numbers should correlate to their position
+    // in this vector
     void rm_node(index_type i) {
       LIBSEMIGROUPS_ASSERT(i < _nodes.size());
-      _nodes.erase(_nodes.begin() + i);
+      // _nodes.erase(_nodes.begin() + i);
     }
   };
 

--- a/include/libsemigroups/aho-corasick.hpp
+++ b/include/libsemigroups/aho-corasick.hpp
@@ -158,12 +158,12 @@ namespace libsemigroups {
       _nodes[parent_index].children().erase(parent_letter);
     }
 
-    void rm_word_no_checks(word_type const& w) {
-      rm_word_no_checks(w.cbegin(), w.cend());
-    }
-
     void add_word_no_checks(word_type const& w) {
       add_word_no_checks(w.cbegin(), w.cend());
+    }
+
+    void rm_word_no_checks(word_type const& w) {
+      rm_word_no_checks(w.cbegin(), w.cend());
     }
 
     // TODO to cpp

--- a/include/libsemigroups/aho-corasick.hpp
+++ b/include/libsemigroups/aho-corasick.hpp
@@ -166,10 +166,6 @@ namespace libsemigroups {
       add_word_no_checks(w.cbegin(), w.cend());
     }
 
-    void rm_word_no_checks(word_type const& w) {
-      rm_word_no_checks(w.cbegin(), w.cend());
-    }
-
     // TODO to cpp
     [[nodiscard]] index_type traverse(const_iterator first,
                                       const_iterator last) const {

--- a/tests/test-aho-corasick.cpp
+++ b/tests/test-aho-corasick.cpp
@@ -38,8 +38,58 @@ namespace libsemigroups {
     REQUIRE(ac.traverse(00101_w) == 5);
     REQUIRE(ac.traverse(010_w) == 7);
 
-    std::ofstream file("aho.gv");
-    file << dot(ac).to_string();
+    // std::ofstream file("aho.gv");
+    // file << dot(ac).to_string();
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("AhoCorasick",
+                          "001",
+                          "all words size 4",
+                          "[quick][aho-corasick]") {
+    AhoCorasick ac;
+    ac.add_word_no_checks(0000_w);
+    ac.add_word_no_checks(0001_w);
+    ac.add_word_no_checks(0010_w);
+    ac.add_word_no_checks(0011_w);
+    ac.add_word_no_checks(0100_w);
+    ac.add_word_no_checks(0101_w);
+    ac.add_word_no_checks(0110_w);
+    ac.add_word_no_checks(0111_w);
+    ac.add_word_no_checks(1000_w);
+    ac.add_word_no_checks(1001_w);
+    ac.add_word_no_checks(1010_w);
+    ac.add_word_no_checks(1011_w);
+    ac.add_word_no_checks(1100_w);
+    ac.add_word_no_checks(1101_w);
+    ac.add_word_no_checks(1110_w);
+    ac.add_word_no_checks(1111_w);
+
+    REQUIRE(ac.number_of_nodes() == 31);
+
+    REQUIRE(ac.traverse(0000_w) == 4);
+    REQUIRE(ac.traverse(0001_w) == 5);
+    REQUIRE(ac.traverse(0010_w) == 7);
+    REQUIRE(ac.traverse(0011_w) == 8);
+    REQUIRE(ac.traverse(0100_w) == 11);
+    REQUIRE(ac.traverse(0101_w) == 12);
+    REQUIRE(ac.traverse(0110_w) == 14);
+    REQUIRE(ac.traverse(0111_w) == 15);
+    REQUIRE(ac.traverse(1000_w) == 19);
+    REQUIRE(ac.traverse(1001_w) == 20);
+    REQUIRE(ac.traverse(1010_w) == 22);
+    REQUIRE(ac.traverse(1011_w) == 23);
+    REQUIRE(ac.traverse(1100_w) == 26);
+    REQUIRE(ac.traverse(1101_w) == 27);
+    REQUIRE(ac.traverse(1110_w) == 29);
+    REQUIRE(ac.traverse(1111_w) == 30);
+
+    // Should do nothing
+    ac.rm_word_no_checks(000_w);
+    REQUIRE(ac.number_of_nodes() == 31);
+
+    ac.rm_word_no_checks(0111_w);
+    REQUIRE(ac.number_of_nodes() == 30);
+    ac.traverse(0111_w);
   }
 
   LIBSEMIGROUPS_TEST_CASE("AhoCorasick",


### PR DESCRIPTION
This adds a test case that includes edge removals that breaks the current `std::vector` implementation of the nodes. 