### PR TITLE
Only check for overlaps in pairs that we haven't already checked

### DIFF
--- a/include/libsemigroups/detail/aho-corasick-impl.hpp
+++ b/include/libsemigroups/detail/aho-corasick-impl.hpp
@@ -163,7 +163,6 @@ namespace libsemigroups {
           _value = value;
           return *this;
         }
-
       };  // class Node
 
       // TODO(1) if we store pointers here instead of Nodes, then inside the

--- a/include/libsemigroups/detail/aho-corasick-impl.hpp
+++ b/include/libsemigroups/detail/aho-corasick-impl.hpp
@@ -65,6 +65,7 @@ namespace libsemigroups {
         // Private data
         ////////////////////////////////////////////////////////////////////////
        private:
+        mutable size_t                 _last_checked;
         uint32_t                       _height;
         index_type                     _link;
         index_type                     _parent;
@@ -97,6 +98,10 @@ namespace libsemigroups {
         // Getters - public
         ////////////////////////////////////////////////////////////////////////
 
+        [[nodiscard]] size_t last_checked() const noexcept {
+          return _last_checked;
+        }
+
         [[nodiscard]] size_t height() const noexcept {
           return _height;
         }
@@ -126,12 +131,22 @@ namespace libsemigroups {
           return _value;
         }
 
+        ////////////////////////////////////////////////////////////////////////
+        // Setters - public
+        ////////////////////////////////////////////////////////////////////////
+
+        Node const& last_checked(size_t val) const noexcept {
+          _last_checked = val;
+          return *this;
+        }
+
        private:
         ////////////////////////////////////////////////////////////////////////
         // Setters - private
         ////////////////////////////////////////////////////////////////////////
 
-        // All setters are private to avoid corrupting the objects.
+        // All setters of non-mutable members are private to avoid corrupting
+        // the objects.
 
         Node const& height(size_t val) noexcept {
           _height = val;
@@ -162,6 +177,7 @@ namespace libsemigroups {
       std::vector<index_type>           _inactive_nodes_index;
       std::vector<index_type>           _node_indices_to_update;
       std::unordered_set<index_type>    _terminal_nodes_index;
+      mutable size_t                    _generation;
 
       // TODO(1): it seems likely that the positions of the active nodes in
       // _all_nodes will become scattered and disordered over time, and so it'd
@@ -186,6 +202,14 @@ namespace libsemigroups {
       AhoCorasickImpl& operator=(AhoCorasickImpl&&);
 
       ~AhoCorasickImpl();
+
+      void increment_generation() const noexcept {
+        ++_generation;
+      }
+
+      size_t generation() const noexcept {
+        return _generation;
+      }
 
       size_t alphabet_size() const noexcept {
         return _children.number_of_cols();
@@ -407,7 +431,7 @@ namespace libsemigroups {
                                               Word const&            w);
 
     }  // namespace aho_corasick_impl
-  }  // namespace detail
+  }    // namespace detail
 }  // namespace libsemigroups
 
 #include "aho-corasick-impl.tpp"

--- a/include/libsemigroups/detail/aho-corasick-impl.tpp
+++ b/include/libsemigroups/detail/aho-corasick-impl.tpp
@@ -29,6 +29,7 @@ namespace libsemigroups {
       LIBSEMIGROUPS_ASSERT(val != nullptr);
       index_type current = root;
       for (auto it = first; it != last; ++it) {
+        _all_nodes[current].last_checked(generation());
         index_type next = _children.get(current, *it);
         if (next == UNDEFINED) {
           // index of next node added
@@ -40,7 +41,7 @@ namespace libsemigroups {
       if (inserted) {
         _all_nodes[current].value(val);
       }
-
+      _all_nodes[current].last_checked(generation());
       return {current, inserted};
     }
 
@@ -309,5 +310,5 @@ namespace libsemigroups {
       }
 
     }  // namespace aho_corasick_impl
-  }  // namespace detail
+  }    // namespace detail
 }  // namespace libsemigroups

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -831,7 +831,7 @@ namespace libsemigroups {
 
       bool finished_impl() const override;
     };  // class KnuthBendixImpl
-  }  // namespace detail
+  }     // namespace detail
 
 ////////////////////////////////////////////////////////////////////////
 // global functions - to_human_readable_repr

--- a/include/libsemigroups/detail/knuth-bendix-impl.tpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.tpp
@@ -565,6 +565,7 @@ namespace libsemigroups {
             _rewriter.add_rule(u.begin(), u.end(), v.begin(), v.end());
             ++start;
           }
+          _rewriter.trie().increment_generation();
         } else {
           // _rewriter.rules() calls process_pending_rules, so can't call it
           // inside the rule1 loop below.

--- a/include/libsemigroups/detail/knuth-bendix-nf.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-nf.hpp
@@ -39,7 +39,7 @@ namespace libsemigroups {
     class KnuthBendixNormalFormRange : public Paths<uint32_t> {
       using Paths_ = Paths<uint32_t>;
 
-      mutable Word                                 _current;
+      mutable Word                                        _current;
       KnuthBendix<Word, RewritingSystem, ReductionOrder>* _kb;
 
      public:
@@ -113,14 +113,14 @@ namespace libsemigroups {
 
     template <typename Word, typename RewritingSystem, typename ReductionOrder>
     KnuthBendixNormalFormRange<Word, RewritingSystem, ReductionOrder>&
-    KnuthBendixNormalFormRange<Word, RewritingSystem, ReductionOrder>::operator=(
-        KnuthBendixNormalFormRange const&)
+    KnuthBendixNormalFormRange<Word, RewritingSystem, ReductionOrder>::
+    operator=(KnuthBendixNormalFormRange const&)
         = default;
 
     template <typename Word, typename RewritingSystem, typename ReductionOrder>
     KnuthBendixNormalFormRange<Word, RewritingSystem, ReductionOrder>&
-    KnuthBendixNormalFormRange<Word, RewritingSystem, ReductionOrder>::operator=(
-        KnuthBendixNormalFormRange&&)
+    KnuthBendixNormalFormRange<Word, RewritingSystem, ReductionOrder>::
+    operator=(KnuthBendixNormalFormRange&&)
         = default;
 
     template <typename Word, typename RewritingSystem, typename ReductionOrder>

--- a/include/libsemigroups/detail/overlap-iterators.hpp
+++ b/include/libsemigroups/detail/overlap-iterators.hpp
@@ -87,7 +87,7 @@ namespace libsemigroups::detail {
           _suffix_descendent_index(),
           _overlap(),
           _trie(nullptr),
-          _index_stack() {};
+          _index_stack(){};
 
     // TODO: Use an init rather than setting default values?
     OverlapIteratorTrie(Trie const& trie)
@@ -177,9 +177,11 @@ namespace libsemigroups::detail {
     // TODO better name
     bool traverse_to_root() {
       while (_suffix_index != Trie::root) {
-        _index_stack.emplace_back(_suffix_index);
-        if (find_next_descendent()) {
-          return true;
+        if (should_check_descendants(_suffix_index)) {
+          _index_stack.emplace_back(_suffix_index);
+          if (find_next_descendent()) {
+            return true;
+          }
         }
         _suffix_index = _trie->node_no_checks(_suffix_index).suffix_link();
       }
@@ -204,12 +206,21 @@ namespace libsemigroups::detail {
         for (letter_type x = 0; x < _trie->alphabet_size(); ++x) {
           index_type child_index
               = _trie->child_no_checks(_suffix_descendent_index, x);
-          if (child_index != UNDEFINED) {
+          if (child_index != UNDEFINED
+              && should_check_descendants(child_index)) {
             _index_stack.emplace_back(child_index);
           }
         }
       }
       return false;
+    }
+
+    // The <generation> of a trie represents which iteration
+    bool should_check_descendants(size_t index) {
+      return _trie->node_no_checks(_word_index).last_checked()
+                 == _trie->generation()
+             || _trie->node_no_checks(index).last_checked()
+                    == _trie->generation();
     }
   };  // class OverlapIteratorTrie
 }  // namespace libsemigroups::detail

--- a/include/libsemigroups/detail/overlap-iterators.hpp
+++ b/include/libsemigroups/detail/overlap-iterators.hpp
@@ -87,10 +87,10 @@ namespace libsemigroups::detail {
           _suffix_descendent_index(),
           _overlap(),
           _trie(nullptr),
-          _index_stack(){};
+          _index_stack() {}
 
     // TODO: Use an init rather than setting default values?
-    OverlapIteratorTrie(Trie const& trie)
+    explicit OverlapIteratorTrie(Trie const& trie)
         : _current_word_iterator(trie.cbegin_terminal_nodes()),
           _last_word_iterator(trie.cend_terminal_nodes()),
           _word_index(Trie::root),
@@ -225,4 +225,4 @@ namespace libsemigroups::detail {
   };  // class OverlapIteratorTrie
 }  // namespace libsemigroups::detail
 
-#endif
+#endif  // LIBSEMIGROUPS_DETAIL_OVERLAP_ITERATORS_HPP_

--- a/include/libsemigroups/detail/rewriters.hpp
+++ b/include/libsemigroups/detail/rewriters.hpp
@@ -386,6 +386,10 @@ namespace libsemigroups {
         return _rule_trie;
       }
 
+      [[nodiscard]] Trie& trie() noexcept {
+        return _rule_trie;
+      }
+
      private:
       ////////////////////////////////////////////////////////////////////////
       // Private member functions

--- a/include/libsemigroups/detail/rewriters.hpp
+++ b/include/libsemigroups/detail/rewriters.hpp
@@ -172,7 +172,6 @@ namespace libsemigroups {
       virtual void report_reducing_rules(
           std::atomic_uint64_t const&,
           std::chrono::high_resolution_clock::time_point const&) const {}
-
     };  // class RewritingSystemBase
 
     ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rules.hpp
+++ b/include/libsemigroups/detail/rules.hpp
@@ -274,4 +274,4 @@ namespace libsemigroups {
 
   }  // namespace detail
 }  // namespace libsemigroups
-#endif
+#endif  // LIBSEMIGROUPS_DETAIL_RULES_HPP_

--- a/include/libsemigroups/detail/rules.hpp
+++ b/include/libsemigroups/detail/rules.hpp
@@ -26,6 +26,7 @@
 #include <cstddef>  // for size_t
 #include <cstdint>  // for uint64_t
 #include <list>     // for list
+#include <string>   // for std::string
 #include <utility>  // for move
 #include <vector>   // for vector
 

--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -64,9 +64,9 @@ namespace libsemigroups {
     //! This function triggers a full enumeration of \p kb.
     //!
     //! \tparam Word the type of the words contained in the output range.
-    //! \tparam RewritingSystem the first template parameter for \ref_knuth_bendix.
-    //! \tparam ReductionOrder the second template parameter for
-    //! \ref_knuth_bendix.
+    //! \tparam RewritingSystem the first template parameter for
+    //! \ref_knuth_bendix. \tparam ReductionOrder the second template parameter
+    //! for \ref_knuth_bendix.
     //!
     //! \param kb the \ref_knuth_bendix instance.
     //!
@@ -79,8 +79,8 @@ namespace libsemigroups {
     template <typename Word, typename RewritingSystem, typename ReductionOrder>
     [[nodiscard]] auto
     normal_forms(KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb) {
-      return detail::KnuthBendixNormalFormRange<Word, RewritingSystem, ReductionOrder>(
-          kb);
+      return detail::
+          KnuthBendixNormalFormRange<Word, RewritingSystem, ReductionOrder>(kb);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -106,9 +106,9 @@ namespace libsemigroups {
     //!
     //! \tparam Word the type of the words contained in the output range
     //! (default: std::string).
-    //! \tparam RewritingSystem the first template parameter for \ref_knuth_bendix.
-    //! \tparam ReductionOrder the second template parameter for
-    //! \ref_knuth_bendix.
+    //! \tparam RewritingSystem the first template parameter for
+    //! \ref_knuth_bendix. \tparam ReductionOrder the second template parameter
+    //! for \ref_knuth_bendix.
     //!
     //! \param kb1 the first \ref_knuth_bendix instance.
     //! \param kb2 the second \ref_knuth_bendix instance.
@@ -128,9 +128,9 @@ namespace libsemigroups {
     //!
     //! \cong_common_warn_undecidable{Knuth-Bendix}.
     template <typename Word, typename RewritingSystem, typename ReductionOrder>
-    [[nodiscard]] std::vector<std::vector<Word>>
-    non_trivial_classes(KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb1,
-                        KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb2);
+    [[nodiscard]] std::vector<std::vector<Word>> non_trivial_classes(
+        KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb1,
+        KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb2);
 
   }  // namespace congruence_common
 
@@ -174,9 +174,9 @@ namespace libsemigroups {
     //!
     //! \tparam Word the type of the words in the
     //! \ref KnuthBendix::presentation.
-    //! \tparam RewritingSystem the first template parameter for \ref_knuth_bendix.
-    //! \tparam ReductionOrder the second template parameter for
-    //! \ref_knuth_bendix.
+    //! \tparam RewritingSystem the first template parameter for
+    //! \ref_knuth_bendix. \tparam ReductionOrder the second template parameter
+    //! for \ref_knuth_bendix.
     //!
     //! \param kb the \ref_knuth_bendix instance.
     //!
@@ -188,7 +188,8 @@ namespace libsemigroups {
     //!
     //! \sa KnuthBendix::run.
     template <typename Word, typename RewritingSystem, typename ReductionOrder>
-    void by_overlap_length(KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb);
+    void
+    by_overlap_length(KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb);
 
     //! \ingroup knuth_bendix_helpers_group
     //!
@@ -198,9 +199,9 @@ namespace libsemigroups {
     //!
     //! \tparam Word the type of the words in the
     //! \ref KnuthBendix::presentation.
-    //! \tparam RewritingSystem the first template parameter for \ref_knuth_bendix.
-    //! \tparam ReductionOrder the second template parameter for
-    //! \ref_knuth_bendix.
+    //! \tparam RewritingSystem the first template parameter for
+    //! \ref_knuth_bendix. \tparam ReductionOrder the second template parameter
+    //! for \ref_knuth_bendix.
     //!
     //! \param kb the \ref_knuth_bendix instance defining the rules that are to
     //! be checked for being reduced.

--- a/include/libsemigroups/obvinf.hpp
+++ b/include/libsemigroups/obvinf.hpp
@@ -649,8 +649,8 @@ namespace libsemigroups {
   //! \note If this function returns \c false, it is still possible that the
   //! quotient defined by the \ref_knuth_bendix object \p kb is infinite.
   template <typename RewritingSystem, typename ReductionOrder>
-  bool
-  is_obviously_infinite(detail::KnuthBendixImpl<RewritingSystem, ReductionOrder>& kb) {
+  bool is_obviously_infinite(
+      detail::KnuthBendixImpl<RewritingSystem, ReductionOrder>& kb) {
     if (kb.finished()) {
       return !v4::word_graph::is_acyclic(kb.gilman_graph());
     }

--- a/include/libsemigroups/to-froidure-pin.hpp
+++ b/include/libsemigroups/to-froidure-pin.hpp
@@ -167,8 +167,9 @@ namespace libsemigroups {
   //! \p kb.
   //!
   //! \tparam Thing used for SFINAE should be FroidurePin.
-  //! \tparam RewritingSystem the second template parameter for \ref_knuth_bendix.
-  //! \tparam ReductionOrder the third template parameter for \ref_knuth_bendix.
+  //! \tparam RewritingSystem the second template parameter for
+  //! \ref_knuth_bendix. \tparam ReductionOrder the third template parameter for
+  //! \ref_knuth_bendix.
   //!
   //! \param kb the \ref_knuth_bendix instance to convert.
   //!
@@ -180,9 +181,11 @@ namespace libsemigroups {
             typename Word,
             typename RewritingSystem,
             typename ReductionOrder>
-  auto to(KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb) -> std::enable_if_t<
-      std::is_same_v<Thing<int>, FroidurePin<int>>,
-      FroidurePin<detail::KBE<KnuthBendix<Word, RewritingSystem, ReductionOrder>>>>;
+  auto to(KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb)
+      -> std::enable_if_t<
+          std::is_same_v<Thing<int>, FroidurePin<int>>,
+          FroidurePin<
+              detail::KBE<KnuthBendix<Word, RewritingSystem, ReductionOrder>>>>;
 
   //! \ingroup to_froidure_pin_group
   //!

--- a/include/libsemigroups/to-froidure-pin.tpp
+++ b/include/libsemigroups/to-froidure-pin.tpp
@@ -27,7 +27,8 @@ namespace libsemigroups {
 
   template <typename Word, typename RewritingSystem, typename ReductionOrder>
   FroidurePin(KnuthBendix<Word, RewritingSystem, ReductionOrder> const&)
-      -> FroidurePin<detail::KBE<KnuthBendix<Word, RewritingSystem, ReductionOrder>>>;
+      -> FroidurePin<
+          detail::KBE<KnuthBendix<Word, RewritingSystem, ReductionOrder>>>;
 
   FroidurePin(detail::ToddCoxeterImpl const&)->FroidurePin<detail::TCE>;
 
@@ -89,9 +90,11 @@ namespace libsemigroups {
             typename Word,
             typename RewritingSystem,
             typename ReductionOrder>
-  auto to(KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb) -> std::enable_if_t<
-      std::is_same_v<Thing<int>, FroidurePin<int>>,
-      FroidurePin<detail::KBE<KnuthBendix<Word, RewritingSystem, ReductionOrder>>>> {
+  auto to(KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb)
+      -> std::enable_if_t<
+          std::is_same_v<Thing<int>, FroidurePin<int>>,
+          FroidurePin<detail::KBE<
+              KnuthBendix<Word, RewritingSystem, ReductionOrder>>>> {
     size_t const n = kb.presentation().alphabet().size();
 
     if (n == 0) {

--- a/include/libsemigroups/to-presentation.hpp
+++ b/include/libsemigroups/to-presentation.hpp
@@ -130,8 +130,9 @@ namespace libsemigroups {
   //! `Presentation<WordOut>` for some type `WordOut`.
   //! \tparam WordIn the type of the rules in the presentation of the
   //! \ref_knuth_bendix object \p kb.
-  //! \tparam RewritingSystem the second template parameter for \ref_knuth_bendix.
-  //! \tparam ReductionOrder the third template parameter for \ref_knuth_bendix.
+  //! \tparam RewritingSystem the second template parameter for
+  //! \ref_knuth_bendix. \tparam ReductionOrder the third template parameter for
+  //! \ref_knuth_bendix.
   //!
   //! \param kb the \ref_knuth_bendix object from which to obtain the rules.
   //!

--- a/include/libsemigroups/to-todd-coxeter.hpp
+++ b/include/libsemigroups/to-todd-coxeter.hpp
@@ -136,7 +136,8 @@ namespace libsemigroups {
             typename Word,
             typename RewritingSystem,
             typename ReductionOrder>
-  auto to(congruence_kind knd, KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb)
+  auto to(congruence_kind                                     knd,
+          KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb)
       -> std::enable_if_t<std::is_same_v<ToddCoxeter<Word>, Thing<Word>>,
                           ToddCoxeter<Word>>;
 

--- a/include/libsemigroups/to-todd-coxeter.tpp
+++ b/include/libsemigroups/to-todd-coxeter.tpp
@@ -54,7 +54,8 @@ namespace libsemigroups {
             typename Word,
             typename RewritingSystem,
             typename ReductionOrder>
-  auto to(congruence_kind knd, KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb)
+  auto to(congruence_kind                                     knd,
+          KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb)
       -> std::enable_if_t<std::is_same_v<ToddCoxeter<Word>, Thing<Word>>,
                           ToddCoxeter<Word>> {
     if (kb.number_of_classes() == POSITIVE_INFINITY) {

--- a/src/detail/aho-corasick-impl.cpp
+++ b/src/detail/aho-corasick-impl.cpp
@@ -103,7 +103,7 @@ namespace libsemigroups {
           _inactive_nodes_index(),
           _node_indices_to_update(),
           _terminal_nodes_index(),
-          _generation(0){};
+          _generation(0) {}
 
     AhoCorasickImpl& AhoCorasickImpl::init(size_t num_letters) {
       LIBSEMIGROUPS_ASSERT(!_all_nodes.empty());

--- a/src/detail/aho-corasick-impl.cpp
+++ b/src/detail/aho-corasick-impl.cpp
@@ -39,7 +39,8 @@ namespace libsemigroups {
     ////////////////////////////////////////////////////////////////////////
 
     AhoCorasickImpl::Node::Node(index_type parent, letter_type a)
-        : _height(),
+        : _last_checked(0),
+          _height(),
           _link(),
           _parent(),
           _parent_letter(),
@@ -50,7 +51,8 @@ namespace libsemigroups {
 
     typename AhoCorasickImpl::Node&
     AhoCorasickImpl::Node::init(index_type parent, letter_type a) noexcept {
-      _height = parent == UNDEFINED ? 0 : UNDEFINED;
+      _height       = parent == UNDEFINED ? 0 : UNDEFINED;
+      _last_checked = 0;
       if (_parent == root || _parent == UNDEFINED) {
         _link = root;
       } else {
@@ -77,7 +79,8 @@ namespace libsemigroups {
           _active_nodes_index({root}),
           _inactive_nodes_index(),
           _node_indices_to_update(),
-          _terminal_nodes_index() {}
+          _terminal_nodes_index(),
+          _generation(0) {}
 
     AhoCorasickImpl& AhoCorasickImpl::init() {
       init(0);
@@ -99,7 +102,8 @@ namespace libsemigroups {
           _active_nodes_index({root}),
           _inactive_nodes_index(),
           _node_indices_to_update(),
-          _terminal_nodes_index() {}
+          _terminal_nodes_index(),
+          _generation(0){};
 
     AhoCorasickImpl& AhoCorasickImpl::init(size_t num_letters) {
       LIBSEMIGROUPS_ASSERT(!_all_nodes.empty());
@@ -124,6 +128,7 @@ namespace libsemigroups {
                                + _inactive_nodes_index.size()
                            == _all_nodes.size());
       LIBSEMIGROUPS_ASSERT(_children.number_of_rows() == _all_nodes.size());
+      _generation = 0;
 
       return *this;
     }

--- a/tests/test-aho-corasick.cpp
+++ b/tests/test-aho-corasick.cpp
@@ -506,7 +506,7 @@ namespace libsemigroups {
                             "017",
                             "terminal_nodes",
                             "[quick]") {
-      using rx::operator|;
+      using rx::      operator|;
       AhoCorasickImpl ac(2);
       REQUIRE((ac.terminal_nodes() | rx::count()) == 0);
 

--- a/tests/test-knuth-bendix-2.cpp
+++ b/tests/test-knuth-bendix-2.cpp
@@ -1808,7 +1808,7 @@ namespace libsemigroups {
     p.alphabet(2);
     presentation::add_idempotent_rules_no_checks(p, 01_w);
     using words::operator+;
-    WordRange words;
+    WordRange    words;
     words.alphabet_size(2).min(0).max(6);
     size_t n = 2;
     for (size_t a = 0; a < n - 1; ++a) {

--- a/tests/test-knuth-bendix-5.cpp
+++ b/tests/test-knuth-bendix-5.cpp
@@ -272,10 +272,11 @@ namespace libsemigroups {
     auto ntc = (iterator_range(pp.begin(), pp.end())
                 | filter([](auto const& val) { return val.size() > 1; })
                 | transform([](auto& val) {
-                    std::for_each(val.begin(), val.end(), [](auto& w) -> auto& {
-                      w.erase(w.begin());
-                      return w;
-                    });
+                    std::for_each(
+                        val.begin(), val.end(), [](auto& w) -> auto& {
+                          w.erase(w.begin());
+                          return w;
+                        });
                     return val;
                   }));
 

--- a/tests/test-knuth-bendix-6.cpp
+++ b/tests/test-knuth-bendix-6.cpp
@@ -359,7 +359,7 @@ namespace libsemigroups {
                                    "[quick][knuth-bendix]",
                                    REWRITING_SYSTEM_TYPES) {
     using literals::operator""_w;
-    auto rg = ReportGuard(false);
+    auto            rg = ReportGuard(false);
 
     Presentation<word_type> p1;
     p1.contains_empty_word(true);

--- a/tests/test-rewriters.cpp
+++ b/tests/test-rewriters.cpp
@@ -504,5 +504,74 @@ namespace libsemigroups {
       ++start;
       REQUIRE(start == end);
     }
+
+    LIBSEMIGROUPS_TEST_CASE("OverlapIteratorTrie",
+                            "017",
+                            "different generations",
+                            "[quick]") {
+      auto                                 rg = ReportGuard(false);
+      RewritingSystemTrie<ShortLexCompare> rt;
+      rt.increase_alphabet_size_by(2);
+
+      // Words added in generation 0
+      rewriting_system::add_rule(rt, "abba"_w, "aaa"_w);
+      rewriting_system::add_rule(rt, "abab"_w, "bbb"_w);
+      rt.reduce();
+
+      // Word added in generation 1
+      rt.trie().increment_generation();
+      rewriting_system::add_rule(rt, "baa"_w, "a"_w);
+      rt.reduce();
+
+      {
+        auto const& trie = rt.trie();
+
+        // Should only find the overlaps between
+        auto start = OverlapIteratorTrie(trie);
+        auto end   = OverlapIteratorTrie();
+
+        v4::ToWord toword(std::string({0, 1}));
+
+        REQUIRE(toword(start->lhs->lhs()) == "baa"_w);
+        REQUIRE(toword(start->lhs->rhs()) == "a"_w);
+        REQUIRE(toword(start->rhs->lhs()) == "abba"_w);
+        REQUIRE(toword(start->rhs->rhs()) == "aaa"_w);
+        REQUIRE(start->length == 1);
+
+        ++start;
+        REQUIRE(toword(start->lhs->lhs()) == "baa"_w);
+        REQUIRE(toword(start->lhs->rhs()) == "a"_w);
+        REQUIRE(toword(start->rhs->lhs()) == "abab"_w);
+        REQUIRE(toword(start->rhs->rhs()) == "bbb"_w);
+        REQUIRE(start->length == 1);
+
+        ++start;
+        REQUIRE(toword(start->lhs->lhs()) == "abba"_w);
+        REQUIRE(toword(start->lhs->rhs()) == "aaa"_w);
+        REQUIRE(toword(start->rhs->lhs()) == "baa"_w);
+        REQUIRE(toword(start->rhs->rhs()) == "a"_w);
+        REQUIRE(start->length == 2);
+
+        ++start;
+        REQUIRE(toword(start->lhs->lhs()) == "abab"_w);
+        REQUIRE(toword(start->lhs->rhs()) == "bbb"_w);
+        REQUIRE(toword(start->rhs->lhs()) == "baa"_w);
+        REQUIRE(toword(start->rhs->rhs()) == "a"_w);
+        REQUIRE(start->length == 1);
+
+        ++start;
+        REQUIRE(start == end);
+      }
+
+      rt.increase_alphabet_size_by(1);
+
+      // Word added in generation 2
+      rt.trie().increment_generation();
+      rewriting_system::add_rule(rt, "c"_w, "b"_w);
+      rt.reduce();
+
+      // No overlaps where at least one word is in generation 2
+      REQUIRE(OverlapIteratorTrie(rt.trie()) == OverlapIteratorTrie());
+    }
   }  // namespace detail
 }  // namespace libsemigroups

--- a/tests/test-to-froidure-pin.cpp
+++ b/tests/test-to-froidure-pin.cpp
@@ -84,7 +84,7 @@ namespace libsemigroups {
   namespace {
     template <typename Word, typename OtherWord = Word>
     void check_from_ke(Presentation<Word> const& p) {
-      using literals::operator""_w;
+      using literals::    operator""_w;
       Kambites<OtherWord> k(twosided, p);
       auto                s = to<FroidurePin>(k);
       REQUIRE(s.is_finite() == tril::FALSE);
@@ -193,7 +193,7 @@ namespace libsemigroups {
                           "from Todd-Coxeter",
                           "[quick][no-valgrind]") {
     using literals::operator""_w;
-    auto rg = ReportGuard(false);
+    auto            rg = ReportGuard(false);
 
     Presentation<word_type> p;
     p.alphabet(4);
@@ -253,7 +253,7 @@ namespace libsemigroups {
                                    "from KnuthBendix",
                                    "[quick]",
                                    REWRITER_TYPES) {
-    using literals::operator""_w;
+    using literals::        operator""_w;
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -277,8 +277,8 @@ namespace libsemigroups {
                           "008",
                           "from ToddCoxeter",
                           "[quick][no-valgrind]") {
-    auto rg = ReportGuard(false);
-    using literals::operator""_w;
+    auto                    rg = ReportGuard(false);
+    using literals::        operator""_w;
     Presentation<word_type> p;
     p.alphabet(4);
     presentation::add_rule(p, 00_w, 0_w);


### PR DESCRIPTION
This PR adds code that reduces the duplicated work the overlap iterator needs to do. The idea of the revised `KnuthBendix` is as follows:

1. Initialise a counter to represent the *generation*.
2. Initialise a trie with the initial relations, where each node of the trie stores the generation in which it was added.
3. While the system is not confluent:
3.1. Find and store all the critical pairs $(u, v)$ where at least one of $u$ or $v$ was added in the current generation.
3.2. Increment the generation.
3.2. Process the critical pairs and add any relevant rules.

In particular, this assumes that *every pair* of relevant critical pairs is found, processed, and added for each generation. If we stop the critical-pair-detection process halfway through a generation, process and add any new relations, and then try to find more critical pairs, we will miss some pairs. In this sense, we aren't quite able to do what we could with the cursors, but it's a step in the right direction.

I'm not at all set on the name `generation` and, given the semigroup context, I'd actually be quite keen to change it but I couldn't think of a good one. 