### PR TITLE
Improve knuth bendix 2 squash

### DIFF
--- a/include/libsemigroups/constants.hpp
+++ b/include/libsemigroups/constants.hpp
@@ -65,13 +65,17 @@ namespace libsemigroups {
       Constant& operator=(Constant&&)      = default;
       ~Constant()                          = default;
 
-      template <typename T, typename = std::enable_if_t<!std::is_enum_v<T>, T>>
+      // We use SFINAE here so that <Constant> is only implicitly converted to
+      // <T> when <T> satisfies a strict set of conditions. This is necessary as
+      // some incorrect implicit conversions were happening in the Python
+      // bindings.
+      template <typename T,
+                typename
+                = std::enable_if_t<!std::is_enum_v<T> && std::is_integral_v<T>
+                                       && (std::is_signed_v<T>
+                                           || std::is_same_v<TMaxOrMin, Max>),
+                                   T>>
       constexpr operator T() const noexcept {
-        static_assert(
-            std::is_integral_v<T>
-                && (std::is_signed_v<T> || std::is_same_v<TMaxOrMin, Max>),
-            "the template parameter T must be an integral type, and either "
-            "unsigned or the template parameter TMaxOrMin must be Max.");
         return TMaxOrMin().template operator()<T>() + TOffset;
       }
     };

--- a/include/libsemigroups/detail/rewriters.tpp
+++ b/include/libsemigroups/detail/rewriters.tpp
@@ -78,7 +78,7 @@ namespace libsemigroups::detail {
 
   template <typename ReductionOrder>
   bool RewritingSystemSet<ReductionOrder>::reduce() {
-    Rules::sort_pending_rules();
+    Rules::sort_pending_rules<ReductionOrder>();
 
     auto   start_time = std::chrono::high_resolution_clock::now();
     Ticker ticker;
@@ -387,7 +387,7 @@ namespace libsemigroups::detail {
     ValueGuard           guard(_ticker_running);
     std::atomic_uint64_t seen = 0;
 
-    Rules::sort_pending_rules();
+    Rules::sort_pending_rules<ReductionOrder>();
 
     bool rules_added = false;
     // TODO(1) could make this a setting, or use a different condition (such

--- a/include/libsemigroups/detail/rules.hpp
+++ b/include/libsemigroups/detail/rules.hpp
@@ -22,13 +22,14 @@
 #ifndef LIBSEMIGROUPS_DETAIL_RULES_HPP_
 #define LIBSEMIGROUPS_DETAIL_RULES_HPP_
 
-#include <array>    // for array
-#include <cstddef>  // for size_t
-#include <cstdint>  // for uint64_t
-#include <list>     // for list
-#include <string>   // for std::string
-#include <utility>  // for move
-#include <vector>   // for vector
+#include <algorithm>  // for std::sort
+#include <array>      // for array
+#include <cstddef>    // for size_t
+#include <cstdint>    // for uint64_t
+#include <list>       // for list
+#include <string>     // for std::string
+#include <utility>    // for move
+#include <vector>     // for vector
 
 #include "libsemigroups/debug.hpp"  // for LIBSEMIGROUPS_ASSERT
 
@@ -179,7 +180,14 @@ namespace libsemigroups {
         _inactive_rules.push_back(rule);
       }
 
-      void sort_pending_rules();
+      template <typename Order>
+      void sort_pending_rules() {
+        std::sort(_pending_rules.begin(),
+                  _pending_rules.end(),
+                  [](Rule const* x, Rule const* y) {
+                    return Order()(x->lhs(), y->lhs());
+                  });
+      }
 
       [[nodiscard]] iterator make_active_rule_pending(iterator it);
 

--- a/src/detail/rules.cpp
+++ b/src/detail/rules.cpp
@@ -159,13 +159,6 @@ namespace libsemigroups {
       }
     }
 
-    void Rules::sort_pending_rules() {
-      std::sort(
-          _pending_rules.begin(),
-          _pending_rules.end(),
-          [](Rule const* x, Rule const* y) { return x->lhs() > y->lhs(); });
-    }
-
     Rules::iterator Rules::make_active_rule_pending(iterator it) {
       LIBSEMIGROUPS_ASSERT((*it)->state() == Rule::State::active);
       LIBSEMIGROUPS_ASSERT((*it)->state() == Rule::State::active);


### PR DESCRIPTION
This PR makes `sort_pending_rules` a function template that accepts arbitrary orderings. When the pending rules are sorted with respect to the reduction order of the rewriting system, bad test case `[932]` now completes in about 20 seconds on my machine. Further changes that prevent the use of a new rule trie speed this up even further, but I didn't want to commit those changes.

It is worth noting that, presently, this makes some of the other tests fail. The failures seem to be related to active rules having their letters permuted. Some of the quick tests are also slower with this change. As a result, I'm not sure whether this PR should actually be merged, but it's good for experimentation.